### PR TITLE
fix(config): replace the hardcoded OpenCode directories by `$XDG_DATA_HOME` then home relative fallback

### DIFF
--- a/ocmonitor/config.py
+++ b/ocmonitor/config.py
@@ -3,16 +3,23 @@
 import json
 import os
 import toml
-from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Dict, Optional
 from pydantic import BaseModel, Field, field_validator
 from decimal import Decimal
 
 
+def opencode_storage_path(path: str | None = None) -> str:
+    base = os.getenv("XDG_DATA_HOME") or "~/.local/share"
+    parts = [base, "opencode", "storage"]
+    if path:
+        parts.append(path)
+    return os.path.join(*parts)
+
+
 class PathsConfig(BaseModel):
     """Configuration for file paths."""
-    messages_dir: str = Field(default="/Users/shelli/.local/share/opencode/storage/message")
-    opencode_storage_dir: str = Field(default="~/.local/share/opencode/storage")
+    messages_dir: str = Field(default=opencode_storage_path("messages"))
+    opencode_storage_dir: str = Field(default=opencode_storage_path())
     export_dir: str = Field(default="./exports")
 
     @field_validator('messages_dir', 'opencode_storage_dir', 'export_dir')


### PR DESCRIPTION
The `messages_dir` setting was hardcoded to your own user location.
This PR fixes it and use `$XDG_DATA_HOME` relative defaults with a fallback on `~/.local/share/opencode/storage`.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full configuration system with UI/export/models/analytics settings and model pricing support.
  * Config can be reloaded at runtime and pricing data is loadable from a JSON source.

* **Improvements**
  * File path handling now expands environment variables and normalizes paths.
  * Default storage locations now follow XDG-compliant directories when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->