### PR TITLE
feat(docker): add Dockerfile + docker-compose workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+__pycache__
+*.pyc
+.venv
+.env*
+*.egg-info
+dist/
+build/
+.pytest_cache/
+test_sessions/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ARG HOST_UID=1000
+RUN useradd -u ${HOST_UID} --home /app --no-create-home app
+ENV HOME=/app
+WORKDIR /app
+
+COPY ./requirements.txt /app
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+RUN python3 -m pip install --no-cache-dir -e .
+
+RUN chown -R app:app /app
+USER app
+
+ENTRYPOINT ["ocmonitor"]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ python3 -m pip install -r requirements.txt
 python3 -m pip install -e .
 ```
 
+**Option 5: Dockerized Installation**
+```bash
+docker compose build
+```
+
+Usage example:
+```bash
+docker compose run --rm ocmonitor sessions
+```
+
+If your host OpenCode data is not in `~/.local/share/opencode`, set `OPENCODE_DATA_DIR` before running:
+```bash
+OPENCODE_DATA_DIR=/your/path/to/opencode/data/dir docker compose run --rm ocmonitor sessions
+```
+
 ### Basic Usage
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  ocmonitor:
+    build:
+      context: .
+      args:
+        HOST_UID: "${UID:-1000}"
+    image: ocmonitor
+    tty: true
+    stdin_open: true
+    user: "${UID:-1000}:${GID:-1000}"
+    environment:
+      - HOME=/app
+      - TERM=xterm-256color
+    volumes:
+      # OpenCode data
+      - ${OPENCODE_DATA_DIR:-$HOME/.local/share/opencode}:/app/.local/share/opencode
+
+      # ocmonitor config + cache
+      - ${OCMONITOR_CONFIG_DIR:-$HOME/.config/ocmonitor}:/app/.config/ocmonitor
+      - ${OCMONITOR_CACHE_DIR:-$HOME/.cache/ocmonitor}:/app/.cache/ocmonitor


### PR DESCRIPTION
This PR adds a Dockerized installation option for ocmonitor.

### What’s included
- Dockerfile for building ocmonitor from source (editable install)
- docker-compose service for running the CLI (supports TTY for `live`)
- README section: “Dockerized Installation” with usage examples

### Usage
```bash
docker compose build
docker compose run --rm ocmonitor sessions
docker compose run --rm ocmonitor live
```

Ref: #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker containerization support for simplified deployment and installation.
  * Build and run the application via Docker Compose.
  * Environment variables to override data, config, and cache directories for flexible setups.

* **Documentation**
  * README updated with a Dockerized installation option, compose commands, and example usage.

* **Chores**
  * Added container build and ignore configuration to streamline Docker builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->