### PR TITLE
Add: support -h as a help alias

### DIFF
--- a/ocmonitor/cli.py
+++ b/ocmonitor/cli.py
@@ -152,7 +152,7 @@ _REPORT_METHOD_MAP = {
 }
 
 
-@click.group()
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=__version__)
 @click.option(
     "--config", "-c", type=click.Path(exists=True), help="Path to configuration file"

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -320,6 +320,7 @@ class TestCLIHelp:
         assert "Usage:" in result.output
 
     def test_main_short_help_alias(self):
+        """Test main CLI short help alias."""
         runner = CliRunner()
         long_help = runner.invoke(cli, ['--help'])
         short_help = runner.invoke(cli, ['-h'])

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -318,6 +318,15 @@ class TestCLIHelp:
         
         assert result.exit_code == 0
         assert "Usage:" in result.output
+
+    def test_main_short_help_alias(self):
+        runner = CliRunner()
+        long_help = runner.invoke(cli, ['--help'])
+        short_help = runner.invoke(cli, ['-h'])
+
+        assert long_help.exit_code == 0
+        assert short_help.exit_code == 0
+        assert short_help.output == long_help.output
     
     def test_sessions_help(self):
         """Test sessions command help."""


### PR DESCRIPTION
## Description
Makes `ocmonitor -h` work the same as `ocmonitor --help`.
Also adds a small CLI test for it.
## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
## How Has This Been Tested?
- [x] Added new test to `tests/integration/test_cli.py`
- [x] Manual testing completed
- [x] Tested with real OpenCode session data
## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top-level CLI now accepts -h as a shorthand for --help, making help accessible with either option.

* **Tests**
  * Added an integration test verifying both -h and --help exit successfully and produce identical help output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->