### PR TITLE
Add bare --week/--month/--year flags for recent period filtering

### DIFF
--- a/ocmonitor/cli.py
+++ b/ocmonitor/cli.py
@@ -46,7 +46,7 @@ def parse_period(ctx, param, value):
             try:
                 return int(value)
             except (ValueError, TypeError):
-                return value
+                raise click.BadParameter("Year must be a valid YYYY format (e.g., 2024)")
         return value
     return None
 

--- a/ocmonitor/cli.py
+++ b/ocmonitor/cli.py
@@ -720,7 +720,8 @@ def weekly(
 
 @cli.command()
 @click.argument("path", type=click.Path(exists=True), required=False)
-@click.option("--year", type=int, help="Year to analyze")
+@click.option("--year", is_flag=False, flag_value="LAST_N_DAYS", default=None, callback=parse_period,
+              help="Year to analyze (YYYY) or bare for last 365 days")
 @click.option(
     "--format",
     "-f",
@@ -742,13 +743,25 @@ def monthly(
 
     PATH: Path to directory containing session folders
           (defaults to configured messages directory)
+
+    Use --year (bare for last periods) to show recent periods.
     """
-    path = resolve_path(path, default_to_messages_dir=True)
+    config = ctx.obj["config"]
+
+    if not path:
+        path = config.paths.messages_dir
+
+    last_n_days = None
+    year_filter = None
+    if year == "LAST_N_DAYS":
+        last_n_days = 365
+    elif year:
+        year_filter = year
 
     with cli_error_context(ctx, "generating monthly breakdown"):
         report_generator = ctx.obj["report_generator"]
         result = report_generator.generate_monthly_report(
-            path, year, output_format, breakdown
+            path, year_filter, output_format, breakdown, last_n_days
         )
 
         handle_output_format(result, output_format)

--- a/ocmonitor/cli.py
+++ b/ocmonitor/cli.py
@@ -37,6 +37,20 @@ def json_serializer(obj):
         return str(obj)
 
 
+def parse_period(ctx, param, value):
+    """Handle --month/--year with optional value."""
+    if value == "LAST_N_DAYS":
+        return "LAST_N_DAYS"
+    if value is not None:
+        if param.name == "year":
+            try:
+                return int(value)
+            except (ValueError, TypeError):
+                return value
+        return value
+    return None
+
+
 @contextmanager
 def cli_error_context(ctx: click.Context, operation_name: str):
     """Context manager for consistent CLI error handling across all commands.
@@ -577,7 +591,11 @@ def live(
 
 @cli.command()
 @click.argument("path", type=click.Path(exists=True), required=False)
-@click.option("--month", type=str, help="Month to analyze (YYYY-MM format)")
+@click.option("--month", is_flag=False, flag_value="LAST_N_DAYS", default=None, callback=parse_period,
+              help="Month to analyze (YYYY-MM format) or bare for last 30 days")
+@click.option("--week", "last_week", is_flag=True, help="Show last 7 days")
+@click.option("--year", is_flag=False, flag_value="LAST_N_DAYS", default=None, callback=parse_period,
+              help="Year to analyze (YYYY) or bare for last 365 days")
 @click.option(
     "--format",
     "-f",
@@ -592,6 +610,8 @@ def daily(
     ctx: click.Context,
     path: Optional[str],
     month: Optional[str],
+    last_week: bool,
+    year: Optional[int],
     output_format: str,
     breakdown: bool,
 ):
@@ -599,13 +619,29 @@ def daily(
 
     PATH: Path to directory containing session folders
           (defaults to configured messages directory)
+
+    Use --week, --month, or --year (bare for last periods) to show recent periods.
     """
-    path = resolve_path(path, default_to_messages_dir=True)
+    config = ctx.obj["config"]
+
+    if not path:
+        path = config.paths.messages_dir
+
+    last_n_days = None
+    year_filter = None
+    if month == "LAST_N_DAYS":
+        last_n_days = 30
+    elif last_week:
+        last_n_days = 7
+    elif year == "LAST_N_DAYS":
+        last_n_days = 365
+    elif year:
+        year_filter = year
 
     with cli_error_context(ctx, "generating daily breakdown"):
         report_generator = ctx.obj["report_generator"]
         result = report_generator.generate_daily_report(
-            path, month, output_format, breakdown
+            path, None if month == "LAST_N_DAYS" else month, output_format, breakdown, last_n_days, year_filter
         )
 
         handle_output_format(result, output_format)
@@ -613,7 +649,10 @@ def daily(
 
 @cli.command()
 @click.argument("path", type=click.Path(exists=True), required=False)
-@click.option("--year", type=int, help="Year to analyze")
+@click.option("--year", is_flag=False, flag_value="LAST_N_DAYS", default=None, callback=parse_period,
+              help="Year to analyze (YYYY) or bare for last 365 days")
+@click.option("--month", is_flag=False, flag_value="LAST_N_DAYS", default=None, callback=parse_period,
+              help="Month to analyze (YYYY-MM) or bare for last 30 days")
 @click.option(
     "--start-day",
     type=click.Choice(
@@ -637,6 +676,7 @@ def weekly(
     ctx: click.Context,
     path: Optional[str],
     year: Optional[int],
+    month: Optional[str],
     start_day: str,
     output_format: str,
     breakdown: bool,
@@ -646,22 +686,33 @@ def weekly(
     PATH: Path to directory containing session folders
           (defaults to configured messages directory)
 
-    Examples:
-        ocmonitor weekly                    # Default (Monday start)
-        ocmonitor weekly --start-day sunday # Sunday to Sunday weeks
-        ocmonitor weekly --start-day friday # Friday to Friday weeks
+    Use --month or --year (bare for last periods) to show recent periods.
     """
-    path = resolve_path(path, default_to_messages_dir=True)
+    config = ctx.obj["config"]
 
-    # Convert day name to weekday number
+    if not path:
+        path = config.paths.messages_dir
+
     from .utils.time_utils import WEEKDAY_MAP
 
     week_start_day = WEEKDAY_MAP[start_day.lower()]
 
+    last_n_days = None
+    year_filter = None
+    month_filter = None
+    if month and month != "LAST_N_DAYS":
+        month_filter = month
+    elif year == "LAST_N_DAYS":
+        last_n_days = 365
+    elif month == "LAST_N_DAYS":
+        last_n_days = 30
+    elif year:
+        year_filter = year
+
     with cli_error_context(ctx, "generating weekly breakdown"):
         report_generator = ctx.obj["report_generator"]
         result = report_generator.generate_weekly_report(
-            path, year, output_format, breakdown, week_start_day
+            path, year_filter, month_filter, output_format, breakdown, week_start_day, last_n_days
         )
 
         handle_output_format(result, output_format)

--- a/ocmonitor/cli.py
+++ b/ocmonitor/cli.py
@@ -43,10 +43,12 @@ def parse_period(ctx, param, value):
         return "LAST_N_DAYS"
     if value is not None:
         if param.name == "year":
-            try:
-                return int(value)
-            except (ValueError, TypeError):
+            if not isinstance(value, str) or not value.isdigit() or len(value) != 4:
                 raise click.BadParameter("Year must be a valid YYYY format (e.g., 2024)")
+            year_int = int(value)
+            if year_int < 1:
+                raise click.BadParameter("Year must be a valid YYYY format (e.g., 2024)")
+            return year_int
         return value
     return None
 
@@ -627,6 +629,16 @@ def daily(
     if not path:
         path = config.paths.messages_dir
 
+    period_opts = 0
+    if month is not None:
+        period_opts += 1
+    if last_week:
+        period_opts += 1
+    if year is not None:
+        period_opts += 1
+    if period_opts > 1:
+        raise click.UsageError("Options --week, --month, and --year are mutually exclusive")
+
     last_n_days = None
     year_filter = None
     if month == "LAST_N_DAYS":
@@ -692,6 +704,9 @@ def weekly(
 
     if not path:
         path = config.paths.messages_dir
+
+    if month is not None and year is not None:
+        raise click.UsageError("Options --month and --year are mutually exclusive")
 
     from .utils.time_utils import WEEKDAY_MAP
 

--- a/ocmonitor/services/report_generator.py
+++ b/ocmonitor/services/report_generator.py
@@ -210,7 +210,11 @@ class ReportGenerator:
         if output_format == "table":
             self._display_daily_breakdown_table(daily_usage, breakdown)
         elif output_format == "json":
-            return self._format_daily_breakdown_json(daily_usage)
+            result = self._format_daily_breakdown_json(daily_usage)
+            result['type'] = 'daily_breakdown'
+            result['filter'] = filter_desc
+            result['filter_label'] = filter_label
+            return result
         elif output_format == "csv":
             return self._format_daily_breakdown_csv(daily_usage)
 
@@ -263,7 +267,10 @@ class ReportGenerator:
             filter_desc = {'last_n_days': last_n_days, 'week_start_day': week_start_day}
             filter_label = 'last ' + str(last_n_days) + ' days'
         else:
-            filter_desc = None
+            if week_start_day != 0:
+                filter_desc = {'week_start_day': week_start_day}
+            else:
+                filter_desc = None
             filter_label = None
 
         report_data = {
@@ -276,7 +283,11 @@ class ReportGenerator:
         if output_format == "table":
             self._display_weekly_breakdown_table(weekly_usage, breakdown, week_start_day)
         elif output_format == "json":
-            return self._format_weekly_breakdown_json(weekly_usage)
+            result = self._format_weekly_breakdown_json(weekly_usage)
+            result['type'] = 'weekly_breakdown'
+            result['filter'] = filter_desc
+            result['filter_label'] = filter_label
+            return result
         elif output_format == "csv":
             return self._format_weekly_breakdown_csv(weekly_usage)
 
@@ -328,7 +339,11 @@ class ReportGenerator:
         if output_format == "table":
             self._display_monthly_breakdown_table(monthly_usage, breakdown)
         elif output_format == "json":
-            return self._format_monthly_breakdown_json(monthly_usage)
+            result = self._format_monthly_breakdown_json(monthly_usage)
+            result['type'] = 'monthly_breakdown'
+            result['filter'] = filter_desc
+            result['filter_label'] = filter_label
+            return result
         elif output_format == "csv":
             return self._format_monthly_breakdown_csv(monthly_usage)
 

--- a/ocmonitor/services/report_generator.py
+++ b/ocmonitor/services/report_generator.py
@@ -188,18 +188,23 @@ class ReportGenerator:
         daily_usage = self.analyzer.create_daily_breakdown(sessions)
 
         if month:
-            filter_desc = 'month: ' + month
+            filter_desc = {'month': month}
+            filter_label = 'month: ' + month
         elif last_n_days:
-            filter_desc = 'last ' + str(last_n_days) + ' days'
+            filter_desc = {'last_n_days': last_n_days}
+            filter_label = 'last ' + str(last_n_days) + ' days'
         elif year:
-            filter_desc = 'year: ' + str(year)
+            filter_desc = {'year': year}
+            filter_label = 'year: ' + str(year)
         else:
             filter_desc = None
+            filter_label = None
 
         report_data = {
             'type': 'daily_breakdown',
             'daily_usage': daily_usage,
-            'filter': filter_desc
+            'filter': filter_desc,
+            'filter_label': filter_label
         }
 
         if output_format == "table":
@@ -250,17 +255,22 @@ class ReportGenerator:
 
         if month:
             filter_desc = {'month': month, 'week_start_day': week_start_day}
+            filter_label = 'month: ' + month
         elif year:
             filter_desc = {'year': year, 'week_start_day': week_start_day}
+            filter_label = 'year: ' + str(year)
         elif last_n_days:
             filter_desc = {'last_n_days': last_n_days, 'week_start_day': week_start_day}
+            filter_label = 'last ' + str(last_n_days) + ' days'
         else:
             filter_desc = None
+            filter_label = None
 
         report_data = {
             'type': 'weekly_breakdown',
             'weekly_usage': weekly_usage,
-            'filter': filter_desc
+            'filter': filter_desc,
+            'filter_label': filter_label
         }
 
         if output_format == "table":
@@ -300,15 +310,19 @@ class ReportGenerator:
 
         if year:
             filter_desc = {'year': year}
+            filter_label = 'year: ' + str(year)
         elif last_n_days:
             filter_desc = {'last_n_days': last_n_days}
+            filter_label = 'last ' + str(last_n_days) + ' days'
         else:
             filter_desc = None
+            filter_label = None
 
         report_data = {
             'type': 'monthly_breakdown',
             'monthly_usage': monthly_usage,
-            'filter': filter_desc
+            'filter': filter_desc,
+            'filter_label': filter_label
         }
 
         if output_format == "table":

--- a/ocmonitor/services/report_generator.py
+++ b/ocmonitor/services/report_generator.py
@@ -154,34 +154,52 @@ class ReportGenerator:
         return report_data
 
     def generate_daily_report(self, base_path: str, month: Optional[str] = None,
-                            output_format: str = "table", breakdown: bool = False) -> Dict[str, Any]:
+                            output_format: str = "table", breakdown: bool = False,
+                            last_n_days: Optional[int] = None,
+                            year: Optional[int] = None) -> Dict[str, Any]:
         """Generate daily breakdown report.
 
         Args:
             base_path: Path to directory containing sessions
             month: Optional month filter (YYYY-MM format)
             output_format: Output format ("table", "json", "csv")
+            last_n_days: Optional - if set, filter to last N days
+            year: Optional year filter (YYYY)
 
         Returns:
             Report data
         """
         sessions = self.analyzer.analyze_all_sessions(base_path)
 
-        # Apply month filter if specified
+        from ..utils.time_utils import TimeUtils
         if month:
-            from ..utils.time_utils import TimeUtils
             month_data = TimeUtils.parse_month_string(month)
             if month_data:
-                year, month_num = month_data
-                start_date, end_date = TimeUtils.get_month_range(year, month_num)
+                year_num, month_num = month_data
+                start_date, end_date = TimeUtils.get_month_range(year_num, month_num)
                 sessions = self.analyzer.filter_sessions_by_date(sessions, start_date, end_date)
+        elif last_n_days:
+            start_date, end_date = TimeUtils.get_last_n_days_range(last_n_days)
+            sessions = self.analyzer.filter_sessions_by_date(sessions, start_date, end_date)
+        elif year:
+            start_date, end_date = TimeUtils.get_year_range(year)
+            sessions = self.analyzer.filter_sessions_by_date(sessions, start_date, end_date)
 
         daily_usage = self.analyzer.create_daily_breakdown(sessions)
+
+        if month:
+            filter_desc = 'month: ' + month
+        elif last_n_days:
+            filter_desc = 'last ' + str(last_n_days) + ' days'
+        elif year:
+            filter_desc = 'year: ' + str(year)
+        else:
+            filter_desc = None
 
         report_data = {
             'type': 'daily_breakdown',
             'daily_usage': daily_usage,
-            'filter': {'month': month} if month else None
+            'filter': filter_desc
         }
 
         if output_format == "table":

--- a/ocmonitor/services/report_generator.py
+++ b/ocmonitor/services/report_generator.py
@@ -212,34 +212,55 @@ class ReportGenerator:
         return report_data
 
     def generate_weekly_report(self, base_path: str, year: Optional[int] = None,
+                              month: Optional[str] = None,
                               output_format: str = "table", breakdown: bool = False,
-                              week_start_day: int = 0) -> Dict[str, Any]:
+                              week_start_day: int = 0,
+                              last_n_days: Optional[int] = None) -> Dict[str, Any]:
         """Generate weekly breakdown report.
 
         Args:
             base_path: Path to directory containing sessions
-            year: Optional year filter
+            year: Optional year filter (YYYY)
+            month: Optional month filter (YYYY-MM format)
             output_format: Output format ("table", "json", "csv")
             breakdown: Show per-model breakdown
             week_start_day: Day to start week on (0=Monday, 6=Sunday)
+            last_n_days: Optional - if set, filter to last N days
 
         Returns:
             Report data
         """
         sessions = self.analyzer.analyze_all_sessions(base_path)
 
-        # Apply year filter if specified
-        if year:
-            from ..utils.time_utils import TimeUtils
+        from ..utils.time_utils import TimeUtils
+        if month:
+            month_data = TimeUtils.parse_month_string(month)
+            if month_data:
+                year_num, month_num = month_data
+                start_date, end_date = TimeUtils.get_month_range(year_num, month_num)
+                sessions = self.analyzer.filter_sessions_by_date(sessions, start_date, end_date)
+        elif year:
             start_date, end_date = TimeUtils.get_year_range(year)
+            sessions = self.analyzer.filter_sessions_by_date(sessions, start_date, end_date)
+        elif last_n_days:
+            start_date, end_date = TimeUtils.get_last_n_days_range(last_n_days)
             sessions = self.analyzer.filter_sessions_by_date(sessions, start_date, end_date)
 
         weekly_usage = self.analyzer.create_weekly_breakdown(sessions, week_start_day)
 
+        if month:
+            filter_desc = {'month': month, 'week_start_day': week_start_day}
+        elif year:
+            filter_desc = {'year': year, 'week_start_day': week_start_day}
+        elif last_n_days:
+            filter_desc = {'last_n_days': last_n_days, 'week_start_day': week_start_day}
+        else:
+            filter_desc = None
+
         report_data = {
             'type': 'weekly_breakdown',
             'weekly_usage': weekly_usage,
-            'filter': {'year': year, 'week_start_day': week_start_day} if year or week_start_day != 0 else None
+            'filter': filter_desc
         }
 
         if output_format == "table":
@@ -252,31 +273,42 @@ class ReportGenerator:
         return report_data
 
     def generate_monthly_report(self, base_path: str, year: Optional[int] = None,
-                              output_format: str = "table", breakdown: bool = False) -> Dict[str, Any]:
+                              output_format: str = "table", breakdown: bool = False,
+                              last_n_days: Optional[int] = None) -> Dict[str, Any]:
         """Generate monthly breakdown report.
 
         Args:
             base_path: Path to directory containing sessions
             year: Optional year filter
             output_format: Output format ("table", "json", "csv")
+            last_n_days: Optional - if set, filter to last N days
 
         Returns:
             Report data
         """
         sessions = self.analyzer.analyze_all_sessions(base_path)
 
-        # Apply year filter if specified
+        from ..utils.time_utils import TimeUtils
         if year:
-            from ..utils.time_utils import TimeUtils
             start_date, end_date = TimeUtils.get_year_range(year)
+            sessions = self.analyzer.filter_sessions_by_date(sessions, start_date, end_date)
+        elif last_n_days:
+            start_date, end_date = TimeUtils.get_last_n_days_range(last_n_days)
             sessions = self.analyzer.filter_sessions_by_date(sessions, start_date, end_date)
 
         monthly_usage = self.analyzer.create_monthly_breakdown(sessions)
 
+        if year:
+            filter_desc = {'year': year}
+        elif last_n_days:
+            filter_desc = {'last_n_days': last_n_days}
+        else:
+            filter_desc = None
+
         report_data = {
             'type': 'monthly_breakdown',
             'monthly_usage': monthly_usage,
-            'filter': {'year': year} if year else None
+            'filter': filter_desc
         }
 
         if output_format == "table":

--- a/ocmonitor/utils/time_utils.py
+++ b/ocmonitor/utils/time_utils.py
@@ -197,6 +197,9 @@ class TimeUtils:
         Returns:
             Tuple of (start_date, end_date) where end_date is today
         """
+        if days <= 0:
+            raise ValueError('days must be a positive integer')
+
         today = date.today()
         start_date = today - timedelta(days=days - 1)
         return start_date, today

--- a/ocmonitor/utils/time_utils.py
+++ b/ocmonitor/utils/time_utils.py
@@ -188,6 +188,20 @@ class TimeUtils:
         return TimeUtils.get_week_range(year, week)
 
     @staticmethod
+    def get_last_n_days_range(days: int) -> Tuple[date, date]:
+        """Get the date range for the last N days (inclusive of today).
+
+        Args:
+            days: Number of days to go back
+
+        Returns:
+            Tuple of (start_date, end_date) where end_date is today
+        """
+        today = date.today()
+        start_date = today - timedelta(days=days - 1)
+        return start_date, today
+
+    @staticmethod
     def get_custom_week_start(target_date: date, week_start_day: int = 0) -> date:
         """Get the start date of the week containing target_date.
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -116,6 +116,37 @@ class TestDailyCommand:
         assert result.exit_code == 0
 
 
+
+
+    def test_daily_invalid_year_rejected(self, mock_sessions_dir):
+        """Test daily command rejects invalid year at parse-time."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['daily', str(mock_sessions_dir), '--year', '20x6'])
+
+        assert result.exit_code == 2
+        assert "Invalid value for '--year'" in result.output
+
+    def test_daily_rejects_multiple_period_options(self, mock_sessions_dir):
+        """Test daily command rejects conflicting period options."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['daily', str(mock_sessions_dir), '--week', '--year', '2024'])
+
+        assert result.exit_code == 2
+        assert 'mutually exclusive' in result.output
+
+    def test_daily_json_includes_filter(self, mock_sessions_dir):
+        """Test daily JSON output includes filter metadata."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['daily', str(mock_sessions_dir), '--year', '2024', '--format', 'json'])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data['type'] == 'daily_breakdown'
+        assert data['filter'] == {'year': 2024}
+        assert data['filter_label'] == 'year: 2024'
+        assert isinstance(data.get('daily_breakdown'), list)
+
+
 class TestWeeklyCommand:
     """Tests for weekly CLI command."""
     
@@ -134,6 +165,37 @@ class TestWeeklyCommand:
         assert result.exit_code == 0
 
 
+
+
+    def test_weekly_invalid_year_rejected(self, mock_sessions_dir):
+        """Test weekly command rejects invalid year at parse-time."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['weekly', str(mock_sessions_dir), '--year', '20x6'])
+
+        assert result.exit_code == 2
+        assert "Invalid value for '--year'" in result.output
+
+    def test_weekly_rejects_month_and_year_together(self, mock_sessions_dir):
+        """Test weekly command rejects --month + --year together."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['weekly', str(mock_sessions_dir), '--month', '2024-01', '--year', '2024'])
+
+        assert result.exit_code == 2
+        assert 'mutually exclusive' in result.output
+
+    def test_weekly_json_includes_week_start_day_filter(self, mock_sessions_dir):
+        """Test weekly JSON output includes week_start_day filter when custom."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['weekly', str(mock_sessions_dir), '--start-day', 'sunday', '--format', 'json'])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data['type'] == 'weekly_breakdown'
+        assert data['filter'] == {'week_start_day': 6}
+        assert data['filter_label'] is None
+        assert isinstance(data.get('weekly_breakdown'), list)
+
+
 class TestMonthlyCommand:
     """Tests for monthly CLI command."""
     
@@ -143,6 +205,29 @@ class TestMonthlyCommand:
         result = runner.invoke(cli, ['monthly', str(mock_sessions_dir)])
         
         assert result.exit_code == 0
+
+
+
+
+    def test_monthly_invalid_year_rejected(self, mock_sessions_dir):
+        """Test monthly command rejects invalid year at parse-time."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['monthly', str(mock_sessions_dir), '--year', '20x6'])
+
+        assert result.exit_code == 2
+        assert "Invalid value for '--year'" in result.output
+
+    def test_monthly_json_includes_filter(self, mock_sessions_dir):
+        """Test monthly JSON output includes filter metadata."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['monthly', str(mock_sessions_dir), '--year', '2024', '--format', 'json'])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data['type'] == 'monthly_breakdown'
+        assert data['filter'] == {'year': 2024}
+        assert data['filter_label'] == 'year: 2024'
+        assert isinstance(data.get('monthly_breakdown'), list)
 
 
 class TestExportCommand:


### PR DESCRIPTION
### Summary
At some point of using ocmonitor calling` ocmonitor daily --breakdown` became pretty annoying to me. I checked for a filters and found them excessive for my simple needs, so I decided to fix that (keeping existing behavior).

This PR adds the ability to use --week, --month and --year flags in bare form (without values) to show data from recent periods. 

### Changes
`ocmonitor/cli.py`
- Added parse_period callback to handle optional flag values
- Updated daily, weekly, and monthly commands with new flag handling logic

`ocmonitor/services/report_generator.py`
- Added month parameter to generate_weekly_report() to properly filter by explicit month values
- Added last_n_days parameter support to all report generators

`ocmonitor/utils/time_utils.py`
- NEW: Added get_last_n_days_range() utility for date range calculation

`tests/integration/test_cli.py`
- Added integration tests covering bare vs explicit flag behavior

`tests/unit/test_time_utils.py`
 - Added unit tests for get_last_n_days_range()

## Bare flags behavior
```
--week   // last 7 days
--month  // last 30 days
--year   // last 365 days
```

## Complete Usage Examples
```
daily	
daily --week	
daily --month	
daily --year	
daily --month 2025-01	
daily --year 2026	
```

```
weekly
weekly --month	
weekly --year	
weekly --month 2026-03	
weekly --year 2025	
```

```
monthly	
monthly --year	
monthly --year 2026	
```

### Breaking Changes
None. Existing syntax continues to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reports: support for last-N-days, sentinel period values, and mutually exclusive period options (week/month/year); monthly/weekly/daily filters unified and consistent
  * JSON output: includes report type, structured filter metadata, and human-readable filter label
  * Utility: helper to compute inclusive last-N-days date ranges

* **Tests**
  * Added integration tests covering CLI parsing, exclusivity rules, and JSON filter metadata
<!-- end of auto-generated comment: release notes by coderabbit.ai -->