### PR TITLE
feat: provider-aware model pricing and display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ OpenCode stores both `providerID` and `modelID` per interaction. This release su
 #### Added
 - **`provider_id` field** on `InteractionFile` — parsed from `providerID` in SQLite message JSON and file-based interactions (`Optional[str]`, default `None`)
 - **`display_model` computed property** on `InteractionFile` — returns `provider/model` when provider is known, else bare model ID
-- **`_split_provider_model()` static helper** on `TableFormatter` and `ReportGenerator` — splits `display_model` on the first `/` for column rendering
+- **`split_provider_model()` static helper** on `FileProcessor` — splits `display_model` on the first `/` for column rendering and is reused by `TableFormatter` and `ReportGenerator`
 - **`_compact_models_display()` method** on `TableFormatter` — groups models by provider in the Daily Usage Breakdown Models column: single model → `provider/model`, multiple from same provider → `provider/{m1, m2}`, truncated to 3 groups with `(+N more)`
 - **Separate Provider and Model columns** in all table builders (`models`, `daily`, `sessions`) and `report_generator.py` workflow table, replacing the former single `Model` column
 
@@ -35,10 +35,15 @@ Old bare-key `models.json` files continue to work without modification:
 - `ocmonitor/models/session.py` — `provider_id`, `display_model`, 5-step lookup
 - `ocmonitor/models/analytics.py` — `create_model_breakdown` uses `display_model`
 - `ocmonitor/utils/sqlite_utils.py` — parses `providerID` from message JSON
-- `ocmonitor/utils/file_utils.py` — parses `providerID` from file interactions
+- `ocmonitor/utils/file_utils.py` — parses `providerID`; provides `lookup_pricing()` (5-step) and `split_provider_model()` helpers
 - `ocmonitor/ui/tables.py` — Provider+Model columns, `_split_provider_model()`, `_compact_models_display()`
 - `ocmonitor/services/report_generator.py` — Provider+Model columns, `_split_provider_model()`
 - `ocmonitor/models.json` — 42 entries in `provider/modelID` format
+
+#### Fixed
+- **Non-deterministic workflow model selection** — `report_generator.py` workflow summary now uses `sorted(set(...))` for stable ordering across runs
+- **Provider/model split helper centralization** — moved split parsing to `FileProcessor.split_provider_model()` and updated all callers
+- **Docstring coverage threshold** — increased docstring coverage to 92.4% (minimum 80%) by adding missing docstrings in touched source and test files
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,42 @@ All notable changes to OpenCode Monitor will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.4] - 2026-04-12
+## [1.0.5] - Unreleased
+
+### 🌐 Provider-Aware Model Pricing
+
+OpenCode stores both `providerID` and `modelID` per interaction. This release surfaces the provider throughout OCMonitor's output and aligns `models.json` keys with the same `provider/modelID` format, enabling accurate per-provider pricing.
+
+#### Added
+- **`provider_id` field** on `InteractionFile` — parsed from `providerID` in SQLite message JSON and file-based interactions (`Optional[str]`, default `None`)
+- **`display_model` computed property** on `InteractionFile` — returns `provider/model` when provider is known, else bare model ID
+- **`_split_provider_model()` static helper** on `TableFormatter` and `ReportGenerator` — splits `display_model` on the first `/` for column rendering
+- **`_compact_models_display()` method** on `TableFormatter` — groups models by provider in the Daily Usage Breakdown Models column: single model → `provider/model`, multiple from same provider → `provider/{m1, m2}`, truncated to 3 groups with `(+N more)`
+- **Separate Provider and Model columns** in all table builders (`models`, `daily`, `sessions`) and `report_generator.py` workflow table, replacing the former single `Model` column
+
+#### Changed
+- **`models.json` key format** migrated from bare `model-id` to `provider/model-id` (e.g., `anthropic/claude-sonnet-4-20250514`). All 42 existing entries updated with canonical provider IDs.
+- **`models_used` and `get_model_breakdown`** now group by `display_model` (provider-qualified)
+- **Prometheus `model` label** now emits `provider/model` values (e.g., `anthropic/claude-sonnet-4-20250514`)
+
+#### Pricing Lookup Chain (5 steps, fully backward compatible)
+Old bare-key `models.json` files continue to work without modification:
+1. `provider_id/model_id` — exact provider+model match
+2. `provider_id/normalize(model_id)` — provider + normalized model
+3. `model_id` — bare exact match (legacy files)
+4. `normalize(model_id)` — bare normalized
+5. Scan `*/model_id` — any provider, model-only fallback
+
+#### Files Modified
+- `ocmonitor/models/session.py` — `provider_id`, `display_model`, 5-step lookup
+- `ocmonitor/models/analytics.py` — `create_model_breakdown` uses `display_model`
+- `ocmonitor/utils/sqlite_utils.py` — parses `providerID` from message JSON
+- `ocmonitor/utils/file_utils.py` — parses `providerID` from file interactions
+- `ocmonitor/ui/tables.py` — Provider+Model columns, `_split_provider_model()`, `_compact_models_display()`
+- `ocmonitor/services/report_generator.py` — Provider+Model columns, `_split_provider_model()`
+- `ocmonitor/models.json` — 42 entries in `provider/modelID` format
+
+
 
 ### ✨ Improvements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,15 +142,27 @@ ocmonitor/
 To add support for a new AI model:
 
 1. **Update models.json**
+
+   Use `provider/model-id` as the key, where `provider` is the canonical provider ID
+   (e.g., `anthropic`, `openai`, `google`) and `model-id` is the model identifier as
+   stored by OpenCode:
+
    ```json
    {
-     "new-model-name": {
-       "input_cost_per_million": 5.0,
-       "output_cost_per_million": 15.0,
-       "context_window": 200000
+     "provider/new-model-id": {
+       "input": 5.0,
+       "output": 15.0,
+       "cacheWrite": 6.25,
+       "cacheRead": 0.50,
+       "contextWindow": 200000,
+       "sessionQuota": 0.0
      }
    }
    ```
+
+   Bare keys (without a provider prefix) are still supported for backward compatibility
+   via the 5-step lookup chain, but all new entries should use the `provider/model-id`
+   format.
 
 2. **Test the Model**
    - Create test session data with the new model

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -710,9 +710,13 @@ Models are defined in the `models.json` file. Each model includes pricing and te
 
 ### Current Models Format
 
+Models are keyed by `provider/model-id`, where `provider` is the canonical provider ID
+(e.g., `anthropic`, `openai`, `google`) and `model-id` matches the model identifier
+stored by OpenCode.
+
 ```json
 {
-  "claude-sonnet-4-20250514": {
+  "anthropic/claude-sonnet-4-20250514": {
     "input": 3.0,
     "output": 15.0,
     "cacheWrite": 3.75,
@@ -721,7 +725,7 @@ Models are defined in the `models.json` file. Each model includes pricing and te
     "sessionQuota": 6.00,
     "description": "Claude Sonnet 4 (2025-05-14)"
   },
-  "claude-opus-4": {
+  "anthropic/claude-opus-4": {
     "input": 15.0,
     "output": 75.0,
     "cacheWrite": 18.75,
@@ -730,7 +734,7 @@ Models are defined in the `models.json` file. Each model includes pricing and te
     "sessionQuota": 10.00,
     "description": "Claude Opus 4"
   },
-  "grok-code": {
+  "opencode/grok-code": {
     "input": 0.0,
     "output": 0.0,
     "cacheWrite": 0.0,
@@ -746,13 +750,13 @@ Models are defined in the `models.json` file. Each model includes pricing and te
 
 #### Step 1: Edit models.json
 
-Add your new model to the `models.json` file:
+Add your new model to the `models.json` file using `provider/model-id` as the key:
 
 ```json
 {
   "existing-models": "...",
   
-  "new-ai-model": {
+  "provider/new-ai-model": {
     "input": 5.0,
     "output": 25.0,
     "cacheWrite": 6.25,
@@ -762,7 +766,7 @@ Add your new model to the `models.json` file:
     "description": "New AI Model"
   },
   
-  "another-model": {
+  "provider/another-model": {
     "input": 0.0,
     "output": 0.0,
     "cacheWrite": 0.0,
@@ -786,9 +790,17 @@ ocmonitor config show
 ocmonitor sessions /path/to/sessions
 ```
 
-#### Step 3: Handle Fully Qualified Names
+#### Step 3: Pricing Lookup Chain
 
-For models with provider prefixes (like `provider/model-name`), add both versions:
+OCMonitor uses a 5-step backward-compatible lookup chain when resolving pricing for
+a session interaction. You only need to add a single `provider/model-id` entry — bare
+model IDs (legacy files) continue to work automatically:
+
+1. `provider_id/model_id` — exact provider+model match
+2. `provider_id/normalize(model_id)` — provider + normalized model
+3. `model_id` — bare exact match (old `models.json` files keep working)
+4. `normalize(model_id)` — bare normalized
+5. Scan `*/model_id` — any provider, model-only fallback
 
 ```json
 {
@@ -800,15 +812,6 @@ For models with provider prefixes (like `provider/model-name`), add both version
     "contextWindow": 150000,
     "sessionQuota": 8.0,
     "description": "Provider Model"
-  },
-  "model-name": {
-    "input": 2.0,
-    "output": 10.0,
-    "cacheWrite": 2.5,
-    "cacheRead": 0.20,
-    "contextWindow": 150000,
-    "sessionQuota": 8.0,
-    "description": "Provider Model (short name)"
   }
 }
 ```
@@ -2061,14 +2064,14 @@ ocmonitor monthly --breakdown
 **Example Output:**
 ```
                              Daily Usage Breakdown                              
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━┓
-┃ Date / Model                   ┃ Sessions ┃ Interactions┃ Total Tokens┃    Cost ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━┩
-│ 2024-01-13                     │        1 │          2 │     1,150 │ $0.0128 │
-│   ↳ claude-sonnet-4-20250514   │        1 │          2 │     1,150 │ $0.0128 │
-│ 2024-01-14                     │        1 │          1 │     5,200 │ $0.0000 │
-│   ↳ grok-code                  │        1 │          1 │     5,200 │ $0.0000 │
-└────────────────────────────────┴──────────┴────────────┴───────────┴─────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━┓
+┃ Date / Model                            ┃ Sessions ┃ Interactions┃ Total Tokens┃    Cost ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━┩
+│ 2024-01-13                              │        1 │          2 │     1,150 │ $0.0128 │
+│   ↳ anthropic/claude-sonnet-4-20250514  │        1 │          2 │     1,150 │ $0.0128 │
+│ 2024-01-14                              │        1 │          1 │     5,200 │ $0.0000 │
+│   ↳ opencode/grok-code                  │        1 │          1 │     5,200 │ $0.0000 │
+└─────────────────────────────────────────┴──────────┴────────────┴───────────┴─────────┘
 ```
 
 **Features:**

--- a/MANUAL_TEST_GUIDE.md
+++ b/MANUAL_TEST_GUIDE.md
@@ -99,6 +99,7 @@ cat > test_sessions/ses_test_001/msg_001.json << 'EOF'
   "id": "msg_001",
   "role": "user",
   "sessionID": "ses_test_001",
+  "providerID": "anthropic",
   "modelID": "claude-sonnet-4-20250514",
   "tokens": {
     "input": 100,
@@ -121,6 +122,7 @@ cat > test_sessions/ses_test_001/msg_002.json << 'EOF'
   "id": "msg_002",
   "role": "assistant",
   "sessionID": "ses_test_001",
+  "providerID": "anthropic",
   "modelID": "claude-sonnet-4-20250514",
   "tokens": {
     "input": 75,
@@ -218,6 +220,7 @@ cat > test_sessions/ses_test_002/msg_001.json << 'EOF'
 {
   "id": "msg_001",
   "sessionID": "ses_test_002",
+  "providerID": "anthropic",
   "modelID": "claude-opus-4",
   "tokens": {
     "input": 200,
@@ -246,9 +249,9 @@ ocmonitor daily test_sessions
 ocmonitor models test_sessions
 ```
 **Expected**:
-- Model usage table
-- Both claude-sonnet-4 and claude-opus-4 listed
-- Token counts and costs per model
+- Model usage table with separate **Provider** and **Model** columns
+- Both `anthropic` / `claude-sonnet-4-20250514` and `anthropic` / `claude-opus-4` listed
+- Token counts and costs per provider/model
 - Percentage breakdown
 
 ## 🔴 Error Handling Tests

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ ocmonitor projects --start-date 2026-01-01 --end-date 2026-02-01
 ```
 
 **Model Analytics Features:**
-- Per-model token usage and cost breakdown
+- Per-provider/model token usage and cost breakdown, with separate **Provider** and **Model** columns
 - Cost percentage distribution across models
 - **Speed Column** - Average output tokens per second for each model
 - Session and interaction counts per model
@@ -383,6 +383,8 @@ curl http://localhost:9090/metrics
 - `ocmonitor_sessions_total{model}` - Session count per model
 - `ocmonitor_session_duration_hours_total` - Total session duration
 - `ocmonitor_sessions_by_project{project}` - Sessions by project
+
+**Note:** The `model` label value is in `provider/model` format (e.g., `anthropic/claude-sonnet-4-20250514`).
 
 ## ⚙️ Configuration
 

--- a/REMOTE_PRICING_FALLBACK_IMPLEMENTATION_PLAN.md
+++ b/REMOTE_PRICING_FALLBACK_IMPLEMENTATION_PLAN.md
@@ -160,10 +160,14 @@ For each `provider_id`, each `model_id`:
 
 ### 7.2 Model key strategy
 
-Generate both keys for better compatibility:
+Generate only the fully-qualified key:
 
-- bare: `<model_id>` (lowercase)
 - fully-qualified: `<provider_id>/<model_id>` (lowercase)
+
+The local pricing lookup chain handles backwards compatibility with existing bare-key
+`models.json` files automatically (see lookup steps 3–5 in section 8.4 below).
+Do not generate bare keys — they cause ambiguity when the same model ID exists under
+multiple providers.
 
 Do not overwrite any existing key from user/local sources.
 

--- a/claude.md
+++ b/claude.md
@@ -80,7 +80,7 @@ models.json                    # AI model pricing data (per 1M tokens)
 1. **File Loading** (`utils/file_utils.py:FileProcessor`):
    - Loads OpenCode session JSON files from `~/.local/share/opencode/storage/message/`
    - Each session contains multiple interaction files with token usage data
-   - Extracts: model_id, tokens (input/output/cache_read/cache_write), project_path, timestamps
+   - Extracts: provider_id, model_id, tokens (input/output/cache_read/cache_write), project_path, timestamps
 
 2. **Session Analysis** (`services/session_analyzer.py:SessionAnalyzer`):
    - Aggregates token usage across all interactions in a session
@@ -106,8 +106,9 @@ models.json                    # AI model pricing data (per 1M tokens)
 - Session time tracking with duration and 5-hour quota progress
 
 **Pricing System**:
-- `models.json` defines cost per 1M tokens for each model
-- Format: `{"model-name": {"input": float, "output": float, "cacheWrite": float, "cacheRead": float, "contextWindow": int, "sessionQuota": float}}`
+- `models.json` defines cost per 1M tokens for each model, keyed by `provider/model-id`
+- Format: `{"provider/model-name": {"input": float, "output": float, "cacheWrite": float, "cacheRead": float, "contextWindow": int, "sessionQuota": float}}`
+- Lookup chain (5 steps, backward compatible): `provider/model_id` → `provider/normalize(model_id)` → bare `model_id` → `normalize(model_id)` → scan `*/model_id`
 - Cost calculation in `session_analyzer.py` multiplies token counts by pricing rates
 
 **CLI Commands** (all in `cli.py`):
@@ -137,10 +138,10 @@ Key settings:
 ## Important Patterns
 
 ### Adding a New Model
-Edit `models.json` with pricing structure:
+Edit `models.json` using `provider/model-id` as the key:
 ```json
 {
-  "model-name": {
+  "provider/model-name": {
     "input": 3.00,
     "output": 15.00,
     "cacheWrite": 3.75,

--- a/ocmonitor/config.py
+++ b/ocmonitor/config.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, field_validator
 
 
 def opencode_storage_path(path: Optional[str] = None) -> str:
+    """Return the OpenCode storage directory, optionally with a child path."""
     base = os.getenv("XDG_DATA_HOME") or "~/.local/share"
     parts = [base, "opencode", "storage"]
     if path:
@@ -112,6 +113,7 @@ class CurrencyConfig(BaseModel):
     @field_validator('remote_rates_cache_path')
     @classmethod
     def expand_currency_paths(cls, v):
+        """Expand user and environment variables for currency cache paths."""
         if v is None:
             return v
         return os.path.expanduser(os.path.expandvars(v))

--- a/ocmonitor/models.json
+++ b/ocmonitor/models.json
@@ -1,5 +1,5 @@
 {
-  "big-pickle": {
+  "opencode/big-pickle": {
     "input": 0.0,
     "output": 0.0,
     "cacheWrite": 0.0,
@@ -7,7 +7,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-  "grok-code-fast-1": {
+  "xai/grok-code-fast-1": {
     "input": 0.0,
     "output": 0.0,
     "cacheWrite": 0.0,
@@ -15,7 +15,7 @@
     "contextWindow": 256000,
     "sessionQuota": 0.0
   },
-  "minimax-m2.1-free": {
+  "minimax/minimax-m2.1-free": {
     "input": 0.3,
     "output": 1.2,
     "cacheWrite": 0.375,
@@ -23,7 +23,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-  "minimax-m2.5-free": {
+  "minimax/minimax-m2.5-free": {
     "input": 0.3,
     "output": 1.2,
     "cacheWrite": 0.375,
@@ -31,7 +31,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-  "minimax-m2.5": {
+  "minimax/minimax-m2.5": {
     "input": 0.3,
     "output": 1.2,
     "cacheWrite": 0.375,
@@ -39,7 +39,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-  "minimax-m2.7": {
+  "minimax/minimax-m2.7": {
     "input": 0.3,
     "output": 1.2,
     "cacheWrite": 0.375,
@@ -47,8 +47,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-
-  "kimi-k2.5-free": {
+  "moonshotai/kimi-k2.5-free": {
     "input": 0.6,
     "output": 3.0,
     "cacheWrite": 0.0,
@@ -56,7 +55,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-  "kimi-k2.5": {
+  "moonshotai/kimi-k2.5": {
     "input": 0.6,
     "output": 3.0,
     "cacheWrite": 0.0,
@@ -64,7 +63,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-  "glm-5-free": {
+  "zhipuai/glm-5-free": {
     "input": 1.0,
     "output": 3.2,
     "cacheWrite": 0.0,
@@ -72,7 +71,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-  "glm-5": {
+  "zhipuai/glm-5": {
     "input": 1.0,
     "output": 3.2,
     "cacheWrite": 0.0,
@@ -80,7 +79,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-  "glm-5.1": {
+  "zhipuai/glm-5.1": {
     "input": 1.4,
     "output": 4.4,
     "cacheWrite": 0.0,
@@ -88,7 +87,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-  "glm-4.7-free": {
+  "zhipuai/glm-4.7-free": {
     "input": 0.6,
     "output": 2.2,
     "cacheWrite": 0.0,
@@ -96,7 +95,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-  "glm-4.6": {
+  "zhipuai/glm-4.6": {
     "input": 0.6,
     "output": 2.2,
     "cacheWrite": 0.0,
@@ -104,7 +103,7 @@
     "contextWindow": 200000,
     "sessionQuota": 0.0
   },
-  "kimi-k2": {
+  "moonshotai/kimi-k2": {
     "input": 0.4,
     "output": 2.5,
     "cacheWrite": 0.0,
@@ -112,7 +111,7 @@
     "contextWindow": 256000,
     "sessionQuota": 0.0
   },
-  "kimi-k2-thinking": {
+  "moonshotai/kimi-k2-thinking": {
     "input": 0.4,
     "output": 2.5,
     "cacheWrite": 0.0,
@@ -120,7 +119,7 @@
     "contextWindow": 256000,
     "sessionQuota": 0.0
   },
-  "qwen3-coder-480b": {
+  "alibaba/qwen3-coder-480b": {
     "input": 0.45,
     "output": 1.5,
     "cacheWrite": 0.0,
@@ -128,7 +127,7 @@
     "contextWindow": 256000,
     "sessionQuota": 0.0
   },
-  "qwen3.6-plus-free": {
+  "alibaba/qwen3.6-plus-free": {
     "input": 0.5,
     "output": 3.0,
     "cacheWrite": 0.0,
@@ -136,7 +135,7 @@
     "contextWindow": 256000,
     "sessionQuota": 0.0
   },
-  "qwen3.6-plus": {
+  "alibaba/qwen3.6-plus": {
     "input": 0.5,
     "output": 3.0,
     "cacheWrite": 0.0,
@@ -144,7 +143,7 @@
     "contextWindow": 256000,
     "sessionQuota": 0.0
   },
-  "claude-sonnet-4.5": {
+  "anthropic/claude-sonnet-4.5": {
     "input": 3.0,
     "output": 15.0,
     "cacheWrite": 3.75,
@@ -152,7 +151,7 @@
     "contextWindow": 200000,
     "sessionQuota": 6.0
   },
-  "claude-sonnet-4.5-extended": {
+  "anthropic/claude-sonnet-4.5-extended": {
     "input": 6.0,
     "output": 22.5,
     "cacheWrite": 7.5,
@@ -160,7 +159,7 @@
     "contextWindow": 400000,
     "sessionQuota": 6.0
   },
-  "claude-sonnet-4": {
+  "anthropic/claude-sonnet-4": {
     "input": 3.0,
     "output": 15.0,
     "cacheWrite": 3.75,
@@ -168,7 +167,7 @@
     "contextWindow": 200000,
     "sessionQuota": 6.0
   },
-  "claude-sonnet-4-extended": {
+  "anthropic/claude-sonnet-4-extended": {
     "input": 6.0,
     "output": 22.5,
     "cacheWrite": 7.5,
@@ -176,7 +175,7 @@
     "contextWindow": 400000,
     "sessionQuota": 6.0
   },
-  "claude-haiku-4.5": {
+  "anthropic/claude-haiku-4.5": {
     "input": 1.0,
     "output": 5.0,
     "cacheWrite": 1.25,
@@ -184,7 +183,7 @@
     "contextWindow": 200000,
     "sessionQuota": 6.0
   },
-  "claude-haiku-3.5": {
+  "anthropic/claude-haiku-3.5": {
     "input": 0.8,
     "output": 4.0,
     "cacheWrite": 1.0,
@@ -192,7 +191,7 @@
     "contextWindow": 200000,
     "sessionQuota": 6.0
   },
-  "claude-opus-4.5": {
+  "anthropic/claude-opus-4.5": {
     "input": 5.0,
     "output": 25.0,
     "cacheWrite": 6.25,
@@ -200,13 +199,141 @@
     "contextWindow": 200000,
     "sessionQuota": 10.0
   },
-  "claude-opus-4.6": {
+  "anthropic/claude-opus-4.6": {
     "input": 5.0,
     "output": 25.0,
     "cacheWrite": 6.25,
     "cacheRead": 0.5,
     "contextWindow": 200000,
     "sessionQuota": 10.0
+  },
+  "anthropic/claude-opus-4.1": {
+    "input": 15.0,
+    "output": 75.0,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5,
+    "contextWindow": 200000,
+    "sessionQuota": 10.0
+  },
+  "google/gemini-3-pro": {
+    "input": 2.0,
+    "output": 12.0,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.2,
+    "contextWindow": 1000000,
+    "sessionQuota": 0.0
+  },
+  "google/gemini-3-pro-extended": {
+    "input": 4.0,
+    "output": 18.0,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.4,
+    "contextWindow": 1000000,
+    "sessionQuota": 0.0
+  },
+  "google/gemini-3-flash": {
+    "input": 0.5,
+    "output": 3.0,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.05,
+    "contextWindow": 1000000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5.2": {
+    "input": 1.75,
+    "output": 14.0,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.175,
+    "contextWindow": 400000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14.0,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.175,
+    "contextWindow": 400000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14.0,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.175,
+    "contextWindow": 400000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5.4": {
+    "input": 2.5,
+    "output": 15.0,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.25,
+    "contextWindow": 1000000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5.4-pro": {
+    "input": 30.0,
+    "output": 180.0,
+    "cacheWrite": 0.0,
+    "cacheRead": 30.0,
+    "contextWindow": 1000000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5.1": {
+    "input": 1.07,
+    "output": 8.5,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.107,
+    "contextWindow": 400000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5.1-codex": {
+    "input": 1.07,
+    "output": 8.5,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.107,
+    "contextWindow": 400000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5.1-codex-max": {
+    "input": 1.25,
+    "output": 10.0,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.125,
+    "contextWindow": 400000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2.0,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.025,
+    "contextWindow": 128000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5": {
+    "input": 1.07,
+    "output": 8.5,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.107,
+    "contextWindow": 400000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5-codex": {
+    "input": 1.07,
+    "output": 8.5,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.107,
+    "contextWindow": 400000,
+    "sessionQuota": 0.0
+  },
+  "openai/gpt-5-nano": {
+    "input": 0.0,
+    "output": 0.0,
+    "cacheWrite": 0.0,
+    "cacheRead": 0.0,
+    "contextWindow": 128000,
+    "sessionQuota": 0.0
   },
   "antigravity-claude-opus-4-6-thinking": {
     "input": 5.0,
@@ -215,134 +342,5 @@
     "cacheRead": 0.5,
     "contextWindow": 200000,
     "sessionQuota": 10.0
-  },
-  "claude-opus-4.1": {
-    "input": 15.0,
-    "output": 75.0,
-    "cacheWrite": 18.75,
-    "cacheRead": 1.5,
-    "contextWindow": 200000,
-    "sessionQuota": 10.0
-  },
-  "gemini-3-pro": {
-    "input": 2.0,
-    "output": 12.0,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.2,
-    "contextWindow": 1000000,
-    "sessionQuota": 0.0
-  },
-  "gemini-3-pro-extended": {
-    "input": 4.0,
-    "output": 18.0,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.4,
-    "contextWindow": 1000000,
-    "sessionQuota": 0.0
-  },
-  "gemini-3-flash": {
-    "input": 0.5,
-    "output": 3.0,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.05,
-    "contextWindow": 1000000,
-    "sessionQuota": 0.0
-  },
-  "gpt-5.2": {
-    "input": 1.75,
-    "output": 14.0,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.175,
-    "contextWindow": 400000,
-    "sessionQuota": 0.0
-  },
-
-  "gpt-5.3-codex": {
-    "input": 1.75,
-    "output": 14.0,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.175,
-    "contextWindow": 400000,
-    "sessionQuota": 0.0
-  },
-  "gpt-5.2-codex": {
-    "input": 1.75,
-    "output": 14.0,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.175,
-    "contextWindow": 400000,
-    "sessionQuota": 0.0
-  },
-  "gpt-5.4": {
-    "input": 2.5,
-    "output": 15.0,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.25,
-    "contextWindow": 1000000,
-    "sessionQuota": 0.0
-  },
-  "gpt-5.4-pro": {
-    "input": 30.0,
-    "output": 180.0,
-    "cacheWrite": 0.0,
-    "cacheRead": 30.0,
-    "contextWindow": 1000000,
-    "sessionQuota": 0.0
-  },
-  "gpt-5.1": {
-    "input": 1.07,
-    "output": 8.5,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.107,
-    "contextWindow": 400000,
-    "sessionQuota": 0.0
-  },
-  "gpt-5.1-codex": {
-    "input": 1.07,
-    "output": 8.5,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.107,
-    "contextWindow": 400000,
-    "sessionQuota": 0.0
-  },
-  "gpt-5.1-codex-max": {
-    "input": 1.25,
-    "output": 10.0,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.125,
-    "contextWindow": 400000,
-    "sessionQuota": 0.0
-  },
-  "gpt-5.1-codex-mini": {
-    "input": 0.25,
-    "output": 2.0,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.025,
-    "contextWindow": 128000,
-    "sessionQuota": 0.0
-  },
-  "gpt-5": {
-    "input": 1.07,
-    "output": 8.5,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.107,
-    "contextWindow": 400000,
-    "sessionQuota": 0.0
-  },
-  "gpt-5-codex": {
-    "input": 1.07,
-    "output": 8.5,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.107,
-    "contextWindow": 400000,
-    "sessionQuota": 0.0
-  },
-  "gpt-5-nano": {
-    "input": 0.0,
-    "output": 0.0,
-    "cacheWrite": 0.0,
-    "cacheRead": 0.0,
-    "contextWindow": 128000,
-    "sessionQuota": 0.0
   }
 }

--- a/ocmonitor/models/analytics.py
+++ b/ocmonitor/models/analytics.py
@@ -362,7 +362,7 @@ class TimeframeAnalyzer:
 
         for session in filtered_sessions:
             for model in session.models_used:
-                model_files = [f for f in session.files if f.model_id == model]
+                model_files = [f for f in session.files if f.display_model == model]
                 model_stats = model_data[model]
 
                 # Update token counts

--- a/ocmonitor/models/analytics.py
+++ b/ocmonitor/models/analytics.py
@@ -139,7 +139,7 @@ class MonthlyUsage(BaseModel):
 
 class ModelUsageStats(BaseModel):
     """Model for model-specific usage statistics."""
-    model_name: str
+    display_model: str
     total_tokens: TokenUsage = Field(default_factory=TokenUsage)
     total_sessions: int = Field(default=0)
     total_interactions: int = Field(default=0)
@@ -361,9 +361,9 @@ class TimeframeAnalyzer:
         model_data: Dict[str, ModelStats] = defaultdict(ModelStats)
 
         for session in filtered_sessions:
-            for model in session.models_used:
-                model_files = [f for f in session.files if f.display_model == model]
-                model_stats = model_data[model]
+            for display_model in session.models_used:
+                model_files = [f for f in session.files if f.display_model == display_model]
+                model_stats = model_data[display_model]
 
                 # Update token counts
                 for file in model_files:
@@ -395,9 +395,9 @@ class TimeframeAnalyzer:
 
         # Convert to ModelUsageStats objects
         model_stats_list = []
-        for model_name, stats in model_data.items():
+        for display_model, stats in model_data.items():
             model_stats_list.append(ModelUsageStats(
-                model_name=model_name,
+                display_model=display_model,
                 total_tokens=stats.tokens,
                 total_sessions=len(stats.sessions),
                 total_interactions=stats.interactions,

--- a/ocmonitor/models/analytics.py
+++ b/ocmonitor/models/analytics.py
@@ -348,7 +348,10 @@ class TimeframeAnalyzer:
         
         # Define model stats structure with proper types
         class ModelStats:
+            """Accumulator for per-model aggregates during report creation."""
+
             def __init__(self):
+                """Initialize aggregate fields for a model bucket."""
                 self.tokens = TokenUsage()
                 self.sessions: Set[str] = set()
                 self.interactions = 0
@@ -443,7 +446,10 @@ class TimeframeAnalyzer:
 
         # Define project stats structure with proper types
         class ProjectStats:
+            """Accumulator for per-project aggregates during report creation."""
+
             def __init__(self):
+                """Initialize aggregate fields for a project bucket."""
                 self.tokens = TokenUsage()
                 self.sessions = 0
                 self.interactions = 0

--- a/ocmonitor/models/session.py
+++ b/ocmonitor/models/session.py
@@ -131,44 +131,11 @@ class InteractionFile(BaseModel):
             Calculated cost in USD
         """
         from ..utils.file_utils import FileProcessor
-        pricing = None
-        normalized = FileProcessor._normalize_model_name(self.model_id)
-
-        # Step 1: provider_id/model_id exact match
-        if self.provider_id:
-            key = f"{self.provider_id}/{self.model_id}"
-            if key in pricing_data:
-                pricing = pricing_data[key]
-
-        # Step 2: provider_id/normalize(model_id)
-        if pricing is None and self.provider_id:
-            key = f"{self.provider_id}/{normalized}"
-            if key in pricing_data:
-                pricing = pricing_data[key]
-
-        # Step 3: bare model_id exact match (backward compat / old models.json)
-        if pricing is None and self.model_id in pricing_data:
-            pricing = pricing_data[self.model_id]
-
-        # Step 4: bare normalized exact match (backward compat)
-        if pricing is None and normalized in pricing_data:
-            pricing = pricing_data[normalized]
-
-        # Step 5: scan all keys for */model_id or */normalized
-        # Covers antigravity-style entries and old bare-key user configs
-        if pricing is None:
-            for key, value in pricing_data.items():
-                if '/' in key:
-                    _, key_model = key.split('/', 1)
-                    if key_model == self.model_id or key_model == normalized:
-                        pricing = value
-                        break
-                else:
-                    # Existing prefix-scan for -extended variant matching
-                    if key.replace('-extended', '') == normalized or \
-                       normalized.replace('-extended', '') == key:
-                        pricing = value
-                        break
+        pricing = FileProcessor.lookup_pricing(
+            pricing_data,
+            model_id=self.model_id,
+            provider_id=self.provider_id,
+        )
 
         if pricing is None:
             return Decimal('0.0')

--- a/ocmonitor/models/session.py
+++ b/ocmonitor/models/session.py
@@ -283,8 +283,8 @@ class SessionData(BaseModel):
         """
         breakdown = {}
 
-        for model in self.models_used:
-            model_files = [f for f in self.files if f.display_model == model]
+        for display_model in self.models_used:
+            model_files = [f for f in self.files if f.display_model == display_model]
             model_tokens = TokenUsage()
             model_cost = Decimal('0.0')
             model_duration_ms = 0
@@ -302,7 +302,7 @@ class SessionData(BaseModel):
                     rate = file.tokens.output / (file.time_data.duration_ms / 1000)
                     interaction_rates.append(rate)
 
-            breakdown[model] = {
+            breakdown[display_model] = {
                 'files': len(model_files),
                 'tokens': model_tokens,
                 'cost': model_cost,

--- a/ocmonitor/models/session.py
+++ b/ocmonitor/models/session.py
@@ -117,12 +117,8 @@ class InteractionFile(BaseModel):
     def _calculate_cost_from_tokens(self, pricing_data: Dict[str, Any]) -> Decimal:
         """Calculate cost from token usage using pricing data.
 
-        Lookup chain (stops at first match):
-          1. provider_id/model_id          — exact provider+model match
-          2. provider_id/normalize(model_id) — provider + normalized model
-          3. model_id                        — bare exact (backward compat)
-          4. normalize(model_id)             — bare normalized (backward compat)
-          5. scan */model_id or */normalize  — any provider, model-only match
+        Delegates provider-aware lookup fallback logic to
+        FileProcessor.lookup_pricing.
 
         Args:
             pricing_data: Dictionary of model pricing information

--- a/ocmonitor/models/session.py
+++ b/ocmonitor/models/session.py
@@ -56,6 +56,7 @@ class InteractionFile(BaseModel):
     file_path: Path
     session_id: str
     model_id: str = Field(default="unknown")
+    provider_id: Optional[str] = Field(default=None, description="Provider ID from OpenCode (e.g. github-copilot, genai-nexus)")
     tokens: TokenUsage = Field(default_factory=TokenUsage)
     time_data: Optional[TimeData] = Field(default=None)
     project_path: Optional[str] = Field(default=None, description="Project working directory from OpenCode")
@@ -76,6 +77,17 @@ class InteractionFile(BaseModel):
     def file_name(self) -> str:
         """Get the file name."""
         return self.file_path.name
+
+    @computed_field
+    @property
+    def display_model(self) -> str:
+        """Get the display model string combining provider and model ID.
+
+        Returns 'provider_id/model_id' when provider is known, else just 'model_id'.
+        """
+        if self.provider_id:
+            return f"{self.provider_id}/{self.model_id}"
+        return self.model_id
 
     @computed_field
     @property
@@ -105,35 +117,58 @@ class InteractionFile(BaseModel):
     def _calculate_cost_from_tokens(self, pricing_data: Dict[str, Any]) -> Decimal:
         """Calculate cost from token usage using pricing data.
 
+        Lookup chain (stops at first match):
+          1. provider_id/model_id          — exact provider+model match
+          2. provider_id/normalize(model_id) — provider + normalized model
+          3. model_id                        — bare exact (backward compat)
+          4. normalize(model_id)             — bare normalized (backward compat)
+          5. scan */model_id or */normalize  — any provider, model-only match
+
         Args:
             pricing_data: Dictionary of model pricing information
 
         Returns:
             Calculated cost in USD
         """
+        from ..utils.file_utils import FileProcessor
         pricing = None
+        normalized = FileProcessor._normalize_model_name(self.model_id)
 
-        # First try exact match
-        if self.model_id in pricing_data:
+        # Step 1: provider_id/model_id exact match
+        if self.provider_id:
+            key = f"{self.provider_id}/{self.model_id}"
+            if key in pricing_data:
+                pricing = pricing_data[key]
+
+        # Step 2: provider_id/normalize(model_id)
+        if pricing is None and self.provider_id:
+            key = f"{self.provider_id}/{normalized}"
+            if key in pricing_data:
+                pricing = pricing_data[key]
+
+        # Step 3: bare model_id exact match (backward compat / old models.json)
+        if pricing is None and self.model_id in pricing_data:
             pricing = pricing_data[self.model_id]
-        else:
-            # Try prefix matching - extract base model name
-            # e.g., claude-opus-4.5-20251101 -> claude-opus-4.5
-            from ..utils.file_utils import FileProcessor
-            normalized = FileProcessor._normalize_model_name(self.model_id)
 
-            if normalized in pricing_data:
-                pricing = pricing_data[normalized]
-            else:
-                # Try finding a matching key by prefix
-                for key in pricing_data.keys():
-                    if normalized.startswith(key) or key.startswith(normalized):
-                        # Check if they're similar (same model family)
-                        # e.g., "claude-opus-4.5" matches "claude-opus-4.5-extended"
-                        if key.replace('-extended', '') == normalized or \
-                           normalized.replace('-extended', '') == key:
-                            pricing = pricing_data[key]
-                            break
+        # Step 4: bare normalized exact match (backward compat)
+        if pricing is None and normalized in pricing_data:
+            pricing = pricing_data[normalized]
+
+        # Step 5: scan all keys for */model_id or */normalized
+        # Covers antigravity-style entries and old bare-key user configs
+        if pricing is None:
+            for key, value in pricing_data.items():
+                if '/' in key:
+                    _, key_model = key.split('/', 1)
+                    if key_model == self.model_id or key_model == normalized:
+                        pricing = value
+                        break
+                else:
+                    # Existing prefix-scan for -extended variant matching
+                    if key.replace('-extended', '') == normalized or \
+                       normalized.replace('-extended', '') == key:
+                        pricing = value
+                        break
 
         if pricing is None:
             return Decimal('0.0')
@@ -195,8 +230,11 @@ class SessionData(BaseModel):
     @computed_field
     @property
     def models_used(self) -> List[str]:
-        """Get list of unique models used in this session."""
-        return list(set(file.model_id for file in self.files))
+        """Get list of unique models used in this session.
+
+        Returns 'provider_id/model_id' when provider is known, else just 'model_id'.
+        """
+        return list(set(file.display_model for file in self.files))
 
     @computed_field
     @property
@@ -279,7 +317,7 @@ class SessionData(BaseModel):
         breakdown = {}
 
         for model in self.models_used:
-            model_files = [f for f in self.files if f.model_id == model]
+            model_files = [f for f in self.files if f.display_model == model]
             model_tokens = TokenUsage()
             model_cost = Decimal('0.0')
             model_duration_ms = 0

--- a/ocmonitor/services/export_service.py
+++ b/ocmonitor/services/export_service.py
@@ -321,7 +321,7 @@ class ExportService:
                 converter = self.currency_converter
                 return [
                     {
-                        'model_name': model.model_name,
+                        'model_name': model.display_model,
                         'total_sessions': model.total_sessions,
                         'total_interactions': model.total_interactions,
                         'input_tokens': model.total_tokens.input,

--- a/ocmonitor/services/live_monitor.py
+++ b/ocmonitor/services/live_monitor.py
@@ -182,6 +182,17 @@ class LiveMonitor:
                 )
         else:
             self._displayed_workflow_id = None
+
+    def _lookup_pricing_for_file(
+        self, interaction_file: InteractionFile
+    ) -> Optional[ModelPricing]:
+        """Lookup pricing for an interaction using provider-aware fallback chain."""
+        pricing = FileProcessor.lookup_pricing(
+            self.pricing_data,
+            model_id=interaction_file.model_id,
+            provider_id=interaction_file.provider_id,
+        )
+        return cast(Optional[ModelPricing], pricing)
         self.data_loader = DataLoader()
 
     def _get_file_active_workflows(
@@ -1013,8 +1024,10 @@ class LiveMonitor:
 
         # Get model pricing for quota
         quota = None
-        if recent_file and recent_file.model_id in self.pricing_data:
-            quota = self.pricing_data[recent_file.model_id].session_quota
+        if recent_file:
+            pricing = self._lookup_pricing_for_file(recent_file)
+            if pricing is not None:
+                quota = pricing.session_quota
 
         # Calculate per-model output rates for this session
         per_model_output_rates = self._calculate_session_output_rates(session)
@@ -1082,8 +1095,9 @@ class LiveMonitor:
         default_context_window = 200000
 
         for model_id, recent_file in model_most_recent.items():
-            if model_id in self.pricing_data:
-                context_window = self.pricing_data[model_id].context_window
+            pricing = self._lookup_pricing_for_file(recent_file)
+            if pricing is not None:
+                context_window = pricing.context_window
             else:
                 context_window = default_context_window
 
@@ -1134,8 +1148,10 @@ class LiveMonitor:
 
         # Get model pricing for quota
         quota = None
-        if recent_file and recent_file.model_id in self.pricing_data:
-            quota = self.pricing_data[recent_file.model_id].session_quota
+        if recent_file:
+            pricing = self._lookup_pricing_for_file(recent_file)
+            if pricing is not None:
+                quota = pricing.session_quota
 
         # Load tool usage statistics (file mode - no SQLite fallback)
         tool_stats = self._load_tool_stats_for_workflow(
@@ -1220,8 +1236,9 @@ class LiveMonitor:
         default_context_window = 200000
 
         for model_id, recent_file in model_most_recent.items():
-            if model_id in self.pricing_data:
-                context_window = self.pricing_data[model_id].context_window
+            pricing = self._lookup_pricing_for_file(recent_file)
+            if pricing is not None:
+                context_window = pricing.context_window
             else:
                 context_window = default_context_window
 
@@ -1431,14 +1448,14 @@ class LiveMonitor:
         Returns:
             Context usage information
         """
-        if interaction_file.model_id not in self.pricing_data:
+        model_pricing = self._lookup_pricing_for_file(interaction_file)
+        if model_pricing is None:
             return {
                 "context_size": 0,
                 "context_window": 200000,
                 "usage_percentage": 0.0,
             }
 
-        model_pricing = self.pricing_data[interaction_file.model_id]
         context_window = model_pricing.context_window
 
         # Context size = input + cache read + cache write
@@ -1814,8 +1831,10 @@ class LiveMonitor:
 
         # Get model pricing for quota
         quota = None
-        if recent_file and recent_file.model_id in self.pricing_data:
-            quota = self.pricing_data[recent_file.model_id].session_quota
+        if recent_file:
+            pricing = self._lookup_pricing_for_file(recent_file)
+            if pricing is not None:
+                quota = pricing.session_quota
 
         # Create a workflow wrapper for the dashboard UI
         workflow_wrapper = WorkflowWrapper(workflow, self.pricing_data)
@@ -1911,8 +1930,9 @@ class LiveMonitor:
         default_context_window = 200000
 
         for model_id, recent_file in model_most_recent.items():
-            if model_id in self.pricing_data:
-                context_window = self.pricing_data[model_id].context_window
+            pricing = self._lookup_pricing_for_file(recent_file)
+            if pricing is not None:
+                context_window = pricing.context_window
             else:
                 context_window = default_context_window
 

--- a/ocmonitor/services/live_monitor.py
+++ b/ocmonitor/services/live_monitor.py
@@ -38,6 +38,7 @@ class WorkflowWrapper:
     def __init__(
         self, workflow_dict: Dict[str, Any], pricing_data: Dict[str, ModelPricing]
     ):
+        """Initialize workflow wrapper from SQLite workflow dictionary data."""
         self.main_session: SessionData = workflow_dict["main_session"]
         self.sub_agents: List[SessionData] = workflow_dict["sub_agents"]
         self.all_sessions: List[SessionData] = workflow_dict["all_sessions"]
@@ -1750,6 +1751,7 @@ class LiveMonitor:
             return workflows[0]
 
         def get_latest_activity(workflow: Dict[str, Any]) -> float:
+            """Return latest parent-session activity timestamp for workflow sorting."""
             latest = 0.0
             has_file_activity = False
             main_session = workflow.get("main_session")
@@ -1787,6 +1789,7 @@ class LiveMonitor:
             return workflows[0]
 
         def get_latest_parent_activity(workflow: SessionWorkflow) -> float:
+            """Return latest main-session file modification timestamp."""
             latest = 0.0
             main = workflow.main_session
             if main:

--- a/ocmonitor/services/live_monitor.py
+++ b/ocmonitor/services/live_monitor.py
@@ -182,6 +182,7 @@ class LiveMonitor:
                 )
         else:
             self._displayed_workflow_id = None
+        self.data_loader = DataLoader()
 
     def _lookup_pricing_for_file(
         self, interaction_file: InteractionFile
@@ -193,7 +194,6 @@ class LiveMonitor:
             provider_id=interaction_file.provider_id,
         )
         return cast(Optional[ModelPricing], pricing)
-        self.data_loader = DataLoader()
 
     def _get_file_active_workflows(
         self, base_path: str, allow_fallback: bool = True

--- a/ocmonitor/services/metrics_server.py
+++ b/ocmonitor/services/metrics_server.py
@@ -82,7 +82,7 @@ class OCMonitorCollector:
             )
 
             for model_stats in model_report.model_stats:
-                label = [model_stats.model_name]
+                label = [model_stats.display_model]
                 tokens_input.add_metric(label, model_stats.total_tokens.input)
                 tokens_output.add_metric(label, model_stats.total_tokens.output)
                 tokens_cache_read.add_metric(label, model_stats.total_tokens.cache_read)

--- a/ocmonitor/services/metrics_server.py
+++ b/ocmonitor/services/metrics_server.py
@@ -18,6 +18,7 @@ class OCMonitorCollector:
     """Custom Prometheus collector that loads fresh data on each scrape."""
 
     def __init__(self, pricing_data: Dict[str, ModelPricing]):
+        """Initialize the collector with pricing data and a session analyzer."""
         self._analyzer = SessionAnalyzer(pricing_data)
         self._pricing_data = pricing_data
 
@@ -161,6 +162,7 @@ class MetricsServer:
     """Lightweight HTTP server exposing Prometheus metrics."""
 
     def __init__(self, pricing_data: Dict[str, ModelPricing], host: str = "0.0.0.0", port: int = 9090):
+        """Store server bind settings and pricing data for metric collection."""
         self.pricing_data = pricing_data
         self.host = host
         self.port = port

--- a/ocmonitor/services/report_generator.py
+++ b/ocmonitor/services/report_generator.py
@@ -59,13 +59,13 @@ class ReportGenerator:
         Returns:
             List of model breakdown dicts sorted by cost descending
         """
-        model_data: Dict[str, Dict[str, Any]] = {}
+        by_display_model: Dict[str, Dict[str, Any]] = {}
 
         for session in sessions:
             for file in session.files:
-                model = file.display_model
-                if model not in model_data:
-                    model_data[model] = {
+                display_model = file.display_model
+                if display_model not in by_display_model:
+                    by_display_model[display_model] = {
                         "sessions": set(),
                         "interactions": 0,
                         "tokens": 0,
@@ -75,22 +75,22 @@ class ReportGenerator:
                         "cache_write": 0,
                         "cost": Decimal("0.0"),
                     }
-                model_data[model]["sessions"].add(session.session_id)
-                model_data[model]["interactions"] += 1
-                model_data[model]["tokens"] += file.tokens.total
-                model_data[model]["input_tokens"] += file.tokens.input
-                model_data[model]["output_tokens"] += file.tokens.output
-                model_data[model]["cache_read"] += file.tokens.cache_read
-                model_data[model]["cache_write"] += file.tokens.cache_write
-                model_data[model]["cost"] += file.calculate_cost(
+                by_display_model[display_model]["sessions"].add(session.session_id)
+                by_display_model[display_model]["interactions"] += 1
+                by_display_model[display_model]["tokens"] += file.tokens.total
+                by_display_model[display_model]["input_tokens"] += file.tokens.input
+                by_display_model[display_model]["output_tokens"] += file.tokens.output
+                by_display_model[display_model]["cache_read"] += file.tokens.cache_read
+                by_display_model[display_model]["cache_write"] += file.tokens.cache_write
+                by_display_model[display_model]["cost"] += file.calculate_cost(
                     self.analyzer.pricing_data, force_recalculate
                 )
 
         results = []
-        for model, data in model_data.items():
+        for display_model, data in by_display_model.items():
             results.append(
                 {
-                    "model": model,
+                    "model": display_model,
                     "sessions": len(data["sessions"]),
                     "interactions": data["interactions"],
                     "tokens": data["tokens"],
@@ -875,18 +875,18 @@ class ReportGenerator:
                     all_models.extend(s.models_used)
                 unique_models = list(set(all_models))
                 if len(unique_models) == 1:
-                    model_display = unique_models[0]
+                    display_model = unique_models[0]
                 else:
-                    model_display = f"{unique_models[0]}+{len(unique_models) - 1}"
+                    display_model = f"{unique_models[0]}+{len(unique_models) - 1}"
 
-                wf_prov, wf_mod = FileProcessor.split_provider_model(model_display)
+                provider, model = FileProcessor.split_provider_model(display_model)
 
                 table.add_row(
                     f"[table.row.time]{start_time}[/table.row.time]",
                     f"[table.row.main]{title}[/table.row.main]",
                     f"[table.row.project]{workflow.project_name[:15]}[/table.row.project]",
-                    f"[table.row.model]{wf_prov}[/table.row.model]",
-                    f"[table.row.model]{wf_mod}[/table.row.model]",
+                    f"[table.row.model]{provider}[/table.row.model]",
+                    f"[table.row.model]{model}[/table.row.model]",
                     f"[table.row.model]+{workflow.sub_agent_count}[/table.row.model]",
                     f"[status.success]{sum(s.interaction_count for s in workflow.all_sessions)}[/status.success]",
                     f"[table.row.tokens]{workflow.total_tokens.total:,}[/table.row.tokens]",
@@ -906,20 +906,20 @@ class ReportGenerator:
                 # Get model for main session
                 main_models = main.models_used
                 if len(main_models) == 1:
-                    main_model_display = main_models[0]
+                    display_model = main_models[0]
                 elif len(main_models) > 1:
-                    main_model_display = f"{main_models[0]}+{len(main_models) - 1}"
+                    display_model = f"{main_models[0]}+{len(main_models) - 1}"
                 else:
-                    main_model_display = "-"
+                    display_model = "-"
 
-                main_prov, main_mod = FileProcessor.split_provider_model(main_model_display)
+                provider, model = FileProcessor.split_provider_model(display_model)
 
                 table.add_row(
                     "",  # No separate start time for sub-rows
                     f"  ├─ {main_title}",
                     "",
-                    main_prov,
-                    main_mod,
+                    provider,
+                    model,
                     main.agent or "main",
                     f"{main.interaction_count}",
                     f"{main.total_tokens.total:,}",
@@ -941,20 +941,20 @@ class ReportGenerator:
                     # Get model for sub-agent session
                     sub_models = sub.models_used
                     if len(sub_models) == 1:
-                        sub_model_display = sub_models[0]
+                        display_model = sub_models[0]
                     elif len(sub_models) > 1:
-                        sub_model_display = f"{sub_models[0]}+{len(sub_models) - 1}"
+                        display_model = f"{sub_models[0]}+{len(sub_models) - 1}"
                     else:
-                        sub_model_display = "-"
+                        display_model = "-"
 
-                    sub_prov, sub_mod = FileProcessor.split_provider_model(sub_model_display)
+                    provider, model = FileProcessor.split_provider_model(display_model)
 
                     table.add_row(
                         "",  # No separate start time for sub-rows
                         f"{prefix} {sub_title}",
                         "",
-                        sub_prov,
-                        sub_mod,
+                        provider,
+                        model,
                         sub.agent or "sub",
                         f"{sub.interaction_count}",
                         f"{sub.total_tokens.total:,}",
@@ -981,20 +981,20 @@ class ReportGenerator:
                 # Get model for single session
                 main_models = main.models_used
                 if len(main_models) == 1:
-                    model_display = main_models[0]
+                    display_model = main_models[0]
                 elif len(main_models) > 1:
-                    model_display = f"{main_models[0]}+{len(main_models) - 1}"
+                    display_model = f"{main_models[0]}+{len(main_models) - 1}"
                 else:
-                    model_display = "-"
+                    display_model = "-"
 
-                single_prov, single_mod = FileProcessor.split_provider_model(model_display)
+                provider, model = FileProcessor.split_provider_model(display_model)
 
                 table.add_row(
                     start_time,
                     title,
                     main.project_name[:15],
-                    single_prov,
-                    single_mod,
+                    provider,
+                    model,
                     main.agent or "-",
                     f"{main.interaction_count}",
                     f"{main.total_tokens.total:,}",
@@ -1070,17 +1070,17 @@ class ReportGenerator:
                 model_breakdown = self._get_model_breakdown_for_sessions(
                     day.sessions, force_recalculate
                 )
-                for model_data in model_breakdown:
+                for row in model_breakdown:
                     table.add_row(
-                        f"  ↳ {model_data['model']}",
-                        f"{model_data['sessions']}",
-                        f"{model_data['interactions']}",
-                        f"{model_data['input_tokens']:,}",
-                        f"{model_data['output_tokens']:,}",
-                        f"{model_data['cache_read']:,}",
-                        f"{model_data['cache_write']:,}",
-                        f"{model_data['tokens']:,}",
-                        self._fmt_cost(model_data["cost"]),
+                        f"  ↳ {row['model']}",
+                        f"{row['sessions']}",
+                        f"{row['interactions']}",
+                        f"{row['input_tokens']:,}",
+                        f"{row['output_tokens']:,}",
+                        f"{row['cache_read']:,}",
+                        f"{row['cache_write']:,}",
+                        f"{row['tokens']:,}",
+                        self._fmt_cost(row["cost"]),
                         style="table.row.dim",
                     )
 
@@ -1146,14 +1146,14 @@ class ReportGenerator:
                 model_breakdown = self._get_model_breakdown_for_sessions(
                     week_sessions, force_recalculate
                 )
-                for model_data in model_breakdown:
+                for row in model_breakdown:
                     table.add_row(
                         "",
-                        f"  ↳ {model_data['model']}",
-                        f"{model_data['sessions']}",
-                        f"{model_data['interactions']}",
-                        f"{model_data['tokens']:,}",
-                        self._fmt_cost(model_data["cost"]),
+                        f"  ↳ {row['model']}",
+                        f"{row['sessions']}",
+                        f"{row['interactions']}",
+                        f"{row['tokens']:,}",
+                        self._fmt_cost(row["cost"]),
                         style="table.row.dim",
                     )
 
@@ -1202,13 +1202,13 @@ class ReportGenerator:
                 model_breakdown = self._get_model_breakdown_for_sessions(
                     month_sessions, force_recalculate
                 )
-                for model_data in model_breakdown:
+                for row in model_breakdown:
                     table.add_row(
-                        f"  ↳ {model_data['model']}",
-                        f"{model_data['sessions']}",
-                        f"{model_data['interactions']}",
-                        f"{model_data['tokens']:,}",
-                        self._fmt_cost(model_data["cost"]),
+                        f"  ↳ {row['model']}",
+                        f"{row['sessions']}",
+                        f"{row['interactions']}",
+                        f"{row['tokens']:,}",
+                        self._fmt_cost(row["cost"]),
                         style="table.row.dim",
                     )
 
@@ -1439,7 +1439,7 @@ class ReportGenerator:
             "recalculated": force_recalculate,
             "models": [
                 {
-                    "model_name": model.model_name,
+                    "model_name": model.display_model,
                     "sessions": model.total_sessions,
                     "interactions": model.total_interactions,
                     "tokens": model.total_tokens.model_dump(),
@@ -1594,7 +1594,7 @@ class ReportGenerator:
         """Format models breakdown for CSV export."""
         return [
             {
-                "model_name": model.model_name,
+                "model_name": model.display_model,
                 "sessions": model.total_sessions,
                 "interactions": model.total_interactions,
                 "input_tokens": model.total_tokens.input,

--- a/ocmonitor/services/report_generator.py
+++ b/ocmonitor/services/report_generator.py
@@ -17,6 +17,7 @@ from ..models.session import SessionData
 from ..services.session_analyzer import SessionAnalyzer
 from ..services.session_grouper import SessionGrouper
 from ..ui.tables import TableFormatter
+from ..utils.file_utils import FileProcessor
 
 
 class ReportGenerator:
@@ -45,14 +46,6 @@ class ReportGenerator:
         if self.currency_converter:
             return self.currency_converter.format(amount)
         return f"${amount:.2f}"
-
-    @staticmethod
-    def _split_provider_model(display_model: str) -> tuple:
-        """Split 'provider/model' into (provider, model). Bare model → ('', model)."""
-        if '/' in display_model:
-            provider, _, model = display_model.partition('/')
-            return provider, model
-        return "", display_model
 
     def _get_model_breakdown_for_sessions(
         self, sessions: List[SessionData], force_recalculate: bool = False
@@ -886,7 +879,7 @@ class ReportGenerator:
                 else:
                     model_display = f"{unique_models[0]}+{len(unique_models) - 1}"
 
-                wf_prov, wf_mod = self._split_provider_model(model_display)
+                wf_prov, wf_mod = FileProcessor.split_provider_model(model_display)
 
                 table.add_row(
                     f"[table.row.time]{start_time}[/table.row.time]",
@@ -919,7 +912,7 @@ class ReportGenerator:
                 else:
                     main_model_display = "-"
 
-                main_prov, main_mod = self._split_provider_model(main_model_display)
+                main_prov, main_mod = FileProcessor.split_provider_model(main_model_display)
 
                 table.add_row(
                     "",  # No separate start time for sub-rows
@@ -954,7 +947,7 @@ class ReportGenerator:
                     else:
                         sub_model_display = "-"
 
-                    sub_prov, sub_mod = self._split_provider_model(sub_model_display)
+                    sub_prov, sub_mod = FileProcessor.split_provider_model(sub_model_display)
 
                     table.add_row(
                         "",  # No separate start time for sub-rows
@@ -994,7 +987,7 @@ class ReportGenerator:
                 else:
                     model_display = "-"
 
-                single_prov, single_mod = self._split_provider_model(model_display)
+                single_prov, single_mod = FileProcessor.split_provider_model(model_display)
 
                 table.add_row(
                     start_time,

--- a/ocmonitor/services/report_generator.py
+++ b/ocmonitor/services/report_generator.py
@@ -873,7 +873,7 @@ class ReportGenerator:
                 all_models = []
                 for s in workflow.all_sessions:
                     all_models.extend(s.models_used)
-                unique_models = list(set(all_models))
+                unique_models = sorted(set(all_models))
                 if len(unique_models) == 1:
                     display_model = unique_models[0]
                 else:

--- a/ocmonitor/services/report_generator.py
+++ b/ocmonitor/services/report_generator.py
@@ -70,7 +70,7 @@ class ReportGenerator:
 
         for session in sessions:
             for file in session.files:
-                model = file.model_id
+                model = file.display_model
                 if model not in model_data:
                     model_data[model] = {
                         "sessions": set(),

--- a/ocmonitor/services/report_generator.py
+++ b/ocmonitor/services/report_generator.py
@@ -46,6 +46,14 @@ class ReportGenerator:
             return self.currency_converter.format(amount)
         return f"${amount:.2f}"
 
+    @staticmethod
+    def _split_provider_model(display_model: str) -> tuple:
+        """Split 'provider/model' into (provider, model). Bare model → ('', model)."""
+        if '/' in display_model:
+            provider, _, model = display_model.partition('/')
+            return provider, model
+        return "", display_model
+
     def _get_model_breakdown_for_sessions(
         self, sessions: List[SessionData], force_recalculate: bool = False
     ) -> List[Dict[str, Any]]:
@@ -839,7 +847,8 @@ class ReportGenerator:
         table.add_column(
             "Project", style="table.row.project", no_wrap=True, max_width=15
         )
-        table.add_column("Model", style="table.row.model", no_wrap=True, max_width=20)
+        table.add_column("Provider", style="table.row.model", no_wrap=True, max_width=15)
+        table.add_column("Model", style="table.row.model", no_wrap=True, max_width=25)
         table.add_column(
             "Agent", justify="center", style="table.row.model", no_wrap=True
         )
@@ -877,11 +886,14 @@ class ReportGenerator:
                 else:
                     model_display = f"{unique_models[0]}+{len(unique_models) - 1}"
 
+                wf_prov, wf_mod = self._split_provider_model(model_display)
+
                 table.add_row(
                     f"[table.row.time]{start_time}[/table.row.time]",
                     f"[table.row.main]{title}[/table.row.main]",
                     f"[table.row.project]{workflow.project_name[:15]}[/table.row.project]",
-                    f"[table.row.model]{model_display}[/table.row.model]",
+                    f"[table.row.model]{wf_prov}[/table.row.model]",
+                    f"[table.row.model]{wf_mod}[/table.row.model]",
                     f"[table.row.model]+{workflow.sub_agent_count}[/table.row.model]",
                     f"[status.success]{sum(s.interaction_count for s in workflow.all_sessions)}[/status.success]",
                     f"[table.row.tokens]{workflow.total_tokens.total:,}[/table.row.tokens]",
@@ -907,11 +919,14 @@ class ReportGenerator:
                 else:
                     main_model_display = "-"
 
+                main_prov, main_mod = self._split_provider_model(main_model_display)
+
                 table.add_row(
                     "",  # No separate start time for sub-rows
                     f"  ├─ {main_title}",
                     "",
-                    main_model_display,
+                    main_prov,
+                    main_mod,
                     main.agent or "main",
                     f"{main.interaction_count}",
                     f"{main.total_tokens.total:,}",
@@ -939,11 +954,14 @@ class ReportGenerator:
                     else:
                         sub_model_display = "-"
 
+                    sub_prov, sub_mod = self._split_provider_model(sub_model_display)
+
                     table.add_row(
                         "",  # No separate start time for sub-rows
                         f"{prefix} {sub_title}",
                         "",
-                        sub_model_display,
+                        sub_prov,
+                        sub_mod,
                         sub.agent or "sub",
                         f"{sub.interaction_count}",
                         f"{sub.total_tokens.total:,}",
@@ -976,11 +994,14 @@ class ReportGenerator:
                 else:
                     model_display = "-"
 
+                single_prov, single_mod = self._split_provider_model(model_display)
+
                 table.add_row(
                     start_time,
                     title,
                     main.project_name[:15],
-                    model_display,
+                    single_prov,
+                    single_mod,
                     main.agent or "-",
                     f"{main.interaction_count}",
                     f"{main.total_tokens.total:,}",

--- a/ocmonitor/services/session_analyzer.py
+++ b/ocmonitor/services/session_analyzer.py
@@ -264,6 +264,7 @@ class SessionAnalyzer:
             return sessions
 
         def _matches(query: str, session_models: List[str], model_parts: set[str]) -> bool:
+            """Match provider-qualified or bare model filters against session models."""
             q = query.lower()
             if '/' in q:
                 return q in session_models

--- a/ocmonitor/services/session_analyzer.py
+++ b/ocmonitor/services/session_analyzer.py
@@ -263,6 +263,12 @@ class SessionAnalyzer:
         if not models:
             return sessions
 
+        def _matches(query: str, session_models: List[str], model_parts: set[str]) -> bool:
+            q = query.lower()
+            if '/' in q:
+                return q in session_models
+            return q in model_parts
+
         filtered = []
         for session in sessions:
             session_models = session.models_used
@@ -271,13 +277,7 @@ class SessionAnalyzer:
                 for m in session_models
             }
 
-            def _matches(query: str) -> bool:
-                q = query.lower()
-                if '/' in q:
-                    return q in session_models
-                return q in model_parts
-
-            if any(_matches(model) for model in models):
+            if any(_matches(model, session_models, model_parts) for model in models):
                 filtered.append(session)
 
         return filtered
@@ -412,10 +412,8 @@ class SessionAnalyzer:
         for model in session.models_used:
             if model == 'unknown':
                 continue
-            if '/' in model:
-                provider_id, model_id = model.split('/', 1)
-            else:
-                provider_id, model_id = None, model
+            provider_id, model_id = FileProcessor.split_provider_model(model)
+            provider_id = provider_id or None
             pricing = FileProcessor.lookup_pricing(self.pricing_data, model_id, provider_id)
             if pricing is None:
                 unknown_models.append(model)

--- a/ocmonitor/services/session_analyzer.py
+++ b/ocmonitor/services/session_analyzer.py
@@ -409,14 +409,14 @@ class SessionAnalyzer:
 
         # Check for unknown models
         unknown_models = []
-        for model in session.models_used:
-            if model == 'unknown':
+        for display_model in session.models_used:
+            if display_model == 'unknown':
                 continue
-            provider_id, model_id = FileProcessor.split_provider_model(model)
+            provider_id, model_id = FileProcessor.split_provider_model(display_model)
             provider_id = provider_id or None
             pricing = FileProcessor.lookup_pricing(self.pricing_data, model_id, provider_id)
             if pricing is None:
-                unknown_models.append(model)
+                unknown_models.append(display_model)
         if unknown_models:
             warnings.append(f"Unknown models with no pricing: {', '.join(unknown_models)}")
 

--- a/ocmonitor/services/session_analyzer.py
+++ b/ocmonitor/services/session_analyzer.py
@@ -265,7 +265,19 @@ class SessionAnalyzer:
 
         filtered = []
         for session in sessions:
-            if any(model in session.models_used for model in models):
+            session_models = session.models_used
+            model_parts = {
+                m.split('/', 1)[1] if '/' in m else m
+                for m in session_models
+            }
+
+            def _matches(query: str) -> bool:
+                q = query.lower()
+                if '/' in q:
+                    return q in session_models
+                return q in model_parts
+
+            if any(_matches(model) for model in models):
                 filtered.append(session)
 
         return filtered
@@ -396,7 +408,17 @@ class SessionAnalyzer:
             warnings.append(f"{missing_time} interactions missing time data")
 
         # Check for unknown models
-        unknown_models = [model for model in session.models_used if model not in self.pricing_data and model != 'unknown']
+        unknown_models = []
+        for model in session.models_used:
+            if model == 'unknown':
+                continue
+            if '/' in model:
+                provider_id, model_id = model.split('/', 1)
+            else:
+                provider_id, model_id = None, model
+            pricing = FileProcessor.lookup_pricing(self.pricing_data, model_id, provider_id)
+            if pricing is None:
+                unknown_models.append(model)
         if unknown_models:
             warnings.append(f"Unknown models with no pricing: {', '.join(unknown_models)}")
 

--- a/ocmonitor/ui/dashboard.py
+++ b/ocmonitor/ui/dashboard.py
@@ -634,6 +634,7 @@ class DashboardUI:
         per_model_context = per_model_context or {}
 
         def get_model_info(model_name: str):
+            """Return tokens, cost, context usage, and output rate for a model."""
             if model_name in model_breakdown:
                 stats = model_breakdown[model_name]
                 tokens = stats.get("tokens", {}).total if hasattr(stats.get("tokens", {}), "total") else stats.get("tokens", 0)

--- a/ocmonitor/ui/tables.py
+++ b/ocmonitor/ui/tables.py
@@ -48,6 +48,49 @@ class TableFormatter:
         """Get color for cost based on quota using semantic theme tags."""
         return ColorFormatter.get_cost_color(cost, quota, default_style="table.row.main")
 
+    @staticmethod
+    def _split_provider_model(display_model: str) -> tuple:
+        """Split 'provider/model' into (provider, model). Bare model → ('', model)."""
+        if '/' in display_model:
+            provider, _, model = display_model.partition('/')
+            return provider, model
+        return "", display_model
+
+    @staticmethod
+    def _compact_models_display(models: list, max_groups: int = 3) -> str:
+        """Format a list of provider/model strings compactly.
+
+        Groups models by provider:
+          - single model  → provider/model
+          - multi models  → provider/{model1, model2}
+          - bare model    → model
+        Truncates to max_groups provider-groups with '(+N more)'.
+        """
+        from collections import OrderedDict
+        provider_models: dict = OrderedDict()
+        bare: list = []
+        for dm in models:
+            if '/' in dm:
+                prov, _, mod = dm.partition('/')
+                provider_models.setdefault(prov, [])
+                if mod not in provider_models[prov]:
+                    provider_models[prov].append(mod)
+            else:
+                if dm not in bare:
+                    bare.append(dm)
+
+        parts: list = []
+        for prov, mods in provider_models.items():
+            if len(mods) == 1:
+                parts.append(f"{prov}/{mods[0]}")
+            else:
+                parts.append(f"{prov}/{{{', '.join(mods)}}}")
+        parts.extend(bare)
+
+        if len(parts) <= max_groups:
+            return ", ".join(parts)
+        return ", ".join(parts[:max_groups]) + f" (+{len(parts) - max_groups} more)"
+
     def create_sessions_table(self, sessions: List[SessionData], pricing_data: Dict[str, Any],
                          force_recalculate: bool = False) -> Table:
         """Create a table for multiple sessions using semantic theme styles."""
@@ -62,7 +105,8 @@ class TableFormatter:
         table.add_column("Started", style="table.row.time", no_wrap=True)
         table.add_column("Duration", style="table.row.time", no_wrap=True)
         table.add_column("Session", style="table.row.main", max_width=35)
-        table.add_column("Model", style="table.row.model", max_width=25)
+        table.add_column("Provider", style="table.row.model", max_width=20)
+        table.add_column("Model", style="table.row.model", max_width=30)
         table.add_column("Interactions", justify="right", style="status.success")
         table.add_column("Input Tokens", justify="right", style="table.row.tokens")
         table.add_column("Output Tokens", justify="right", style="table.row.tokens")
@@ -109,9 +153,9 @@ class TableFormatter:
                     session_display = ""
 
                 # Format model name
-                model_text = Text(model)
-                if len(model) > 25:
-                    model_text = Text(f"{model[:22]}...")
+                provider_name, model_name = self._split_provider_model(model)
+                provider_text = Text(provider_name[:17] + "..." if len(provider_name) > 20 else provider_name)
+                model_text = Text(model_name[:27] + "..." if len(model_name) > 30 else model_name)
 
                 # Get cost color
                 cost_color = self.get_cost_color(stats['cost'])
@@ -130,6 +174,7 @@ class TableFormatter:
                     start_time,
                     duration,
                     session_display,
+                    provider_text,
                     model_text,
                     self.format_number(stats['files']),
                     self.format_number(stats['tokens'].input),
@@ -153,6 +198,7 @@ class TableFormatter:
             Text("TOTALS", style="table.footer"),
             "",
             "",  # Empty session column
+            "",  # Empty provider column
             Text(f"{len(sorted_sessions)} sessions", style="table.footer"),
             Text(self.format_number(total_interactions), style="status.success"),
             Text(self.format_number(total_tokens.input), style="table.row.tokens"),
@@ -176,7 +222,8 @@ class TableFormatter:
 
         # Add columns
         table.add_column("File", style="table.row.time", max_width=30)
-        table.add_column("Model", style="table.row.model")
+        table.add_column("Provider", style="table.row.model", max_width=20)
+        table.add_column("Model", style="table.row.model", max_width=30)
         table.add_column("Input", justify="right", style="table.row.tokens")
         table.add_column("Output", justify="right", style="table.row.tokens")
         table.add_column("Cache W", justify="right", style="status.success")
@@ -202,9 +249,12 @@ class TableFormatter:
 
             cost_color = self.get_cost_color(cost)
 
+            prov, mod = self._split_provider_model(file.display_model)
+
             table.add_row(
                 Text(file.file_name[:27] + "..." if len(file.file_name) > 30 else file.file_name),
-                file.model_id,
+                Text(prov[:17] + "..." if len(prov) > 20 else prov),
+                Text(mod[:27] + "..." if len(mod) > 30 else mod),
                 self.format_number(file.tokens.input),
                 self.format_number(file.tokens.output),
                 self.format_number(file.tokens.cache_write),
@@ -218,6 +268,7 @@ class TableFormatter:
         table.add_section()
         table.add_row(
             Text("TOTALS", style="table.footer"),
+            "",
             "",
             Text(self.format_number(total_tokens.input), style="table.row.tokens"),
             Text(self.format_number(total_tokens.output), style="table.row.tokens"),
@@ -267,9 +318,7 @@ class TableFormatter:
             total_tokens.cache_read += day_tokens.cache_read
             total_cost += day_cost
 
-            models_text = ", ".join(day.models_used[:3])
-            if len(day.models_used) > 3:
-                models_text += f" (+{len(day.models_used) - 3} more)"
+            models_text = self._compact_models_display(day.models_used)
 
             cost_color = self.get_cost_color(day_cost)
 
@@ -309,6 +358,7 @@ class TableFormatter:
         )
 
         # Add columns
+        table.add_column("Provider", style="table.row.model", max_width=20)
         table.add_column("Model", style="table.row.model", max_width=30)
         table.add_column("Sessions", justify="right", style="status.success")
         table.add_column("Interactions", justify="right", style="status.success")
@@ -334,8 +384,11 @@ class TableFormatter:
             else:
                 speed_text = f"{speed:.1f} t/s"
 
+            prov, mod = self._split_provider_model(model.model_name)
+
             table.add_row(
-                Text(model.model_name[:27] + "..." if len(model.model_name) > 30 else model.model_name),
+                Text(prov[:17] + "..." if len(prov) > 20 else prov),
+                Text(mod[:27] + "..." if len(mod) > 30 else mod),
                 self.format_number(model.total_sessions),
                 self.format_number(model.total_interactions),
                 self.format_number(model.total_tokens.input),

--- a/ocmonitor/ui/tables.py
+++ b/ocmonitor/ui/tables.py
@@ -66,8 +66,7 @@ class TableFormatter:
           - bare model    → model
         Truncates to max_groups provider-groups with '(+N more)'.
         """
-        from collections import OrderedDict
-        provider_models: dict = OrderedDict()
+        provider_models: dict = {}
         bare: list = []
         for dm in models:
             if '/' in dm:
@@ -80,12 +79,13 @@ class TableFormatter:
                     bare.append(dm)
 
         parts: list = []
-        for prov, mods in provider_models.items():
+        for prov in sorted(provider_models.keys()):
+            mods = sorted(provider_models[prov])
             if len(mods) == 1:
                 parts.append(f"{prov}/{mods[0]}")
             else:
                 parts.append(f"{prov}/{{{', '.join(mods)}}}")
-        parts.extend(bare)
+        parts.extend(sorted(bare))
 
         if len(parts) <= max_groups:
             return ", ".join(parts)

--- a/ocmonitor/ui/tables.py
+++ b/ocmonitor/ui/tables.py
@@ -61,15 +61,15 @@ class TableFormatter:
         """
         provider_models: dict = {}
         bare: list = []
-        for dm in models:
-            if '/' in dm:
-                prov, _, mod = dm.partition('/')
+        for display_model in models:
+            if '/' in display_model:
+                prov, _, mod = display_model.partition('/')
                 provider_models.setdefault(prov, [])
                 if mod not in provider_models[prov]:
                     provider_models[prov].append(mod)
             else:
-                if dm not in bare:
-                    bare.append(dm)
+                if display_model not in bare:
+                    bare.append(display_model)
 
         parts: list = []
         for prov in sorted(provider_models.keys()):
@@ -131,7 +131,7 @@ class TableFormatter:
             model_breakdown = session.get_model_breakdown(pricing_data, force_recalculate)
 
             # Add rows for each model
-            for i, (model, stats) in enumerate(model_breakdown.items()):
+            for i, (display_model, stats) in enumerate(model_breakdown.items()):
                 # Show session info only for first model
                 if i == 0:
                     start_time = session.start_time.strftime('%Y-%m-%d %H:%M:%S') if session.start_time else 'N/A'
@@ -146,9 +146,9 @@ class TableFormatter:
                     session_display = ""
 
                 # Format model name
-                provider_name, model_name = FileProcessor.split_provider_model(model)
-                provider_text = Text(provider_name[:17] + "..." if len(provider_name) > 20 else provider_name)
-                model_text = Text(model_name[:27] + "..." if len(model_name) > 30 else model_name)
+                provider, model = FileProcessor.split_provider_model(display_model)
+                provider_text = Text(provider[:17] + "..." if len(provider) > 20 else provider)
+                model_text = Text(model[:27] + "..." if len(model) > 30 else model)
 
                 # Get cost color
                 cost_color = self.get_cost_color(stats['cost'])
@@ -242,12 +242,12 @@ class TableFormatter:
 
             cost_color = self.get_cost_color(cost)
 
-            prov, mod = FileProcessor.split_provider_model(file.display_model)
+            provider, model = FileProcessor.split_provider_model(file.display_model)
 
             table.add_row(
                 Text(file.file_name[:27] + "..." if len(file.file_name) > 30 else file.file_name),
-                Text(prov[:17] + "..." if len(prov) > 20 else prov),
-                Text(mod[:27] + "..." if len(mod) > 30 else mod),
+                Text(provider[:17] + "..." if len(provider) > 20 else provider),
+                Text(model[:27] + "..." if len(model) > 30 else model),
                 self.format_number(file.tokens.input),
                 self.format_number(file.tokens.output),
                 self.format_number(file.tokens.cache_write),
@@ -364,32 +364,32 @@ class TableFormatter:
         table.add_column("Cost %", justify="right", style="table.row.cost")
         table.add_column("Speed", justify="right", style="table.row.time")
 
-        total_cost = sum(model.total_cost for model in model_stats)
+        total_cost = sum(stat.total_cost for stat in model_stats)
 
-        for model in model_stats:
-            cost_percentage = self.format_percentage(float(model.total_cost), float(total_cost))
-            cost_color = self.get_cost_color(model.total_cost)
+        for stat in model_stats:
+            cost_percentage = self.format_percentage(float(stat.total_cost), float(total_cost))
+            cost_color = self.get_cost_color(stat.total_cost)
 
             # Format speed
-            speed = model.p50_output_rate
+            speed = stat.p50_output_rate
             if speed == 0:
                 speed_text = "-"
             else:
                 speed_text = f"{speed:.1f} t/s"
 
-            prov, mod = FileProcessor.split_provider_model(model.model_name)
+            provider, model = FileProcessor.split_provider_model(stat.display_model)
 
             table.add_row(
-                Text(prov[:17] + "..." if len(prov) > 20 else prov),
-                Text(mod[:27] + "..." if len(mod) > 30 else mod),
-                self.format_number(model.total_sessions),
-                self.format_number(model.total_interactions),
-                self.format_number(model.total_tokens.input),
-                self.format_number(model.total_tokens.output),
-                self.format_number(model.total_tokens.cache_write),
-                self.format_number(model.total_tokens.cache_read),
-                self.format_number(model.total_tokens.total),
-                Text(self.format_currency(model.total_cost), style=cost_color),
+                Text(provider[:17] + "..." if len(provider) > 20 else provider),
+                Text(model[:27] + "..." if len(model) > 30 else model),
+                self.format_number(stat.total_sessions),
+                self.format_number(stat.total_interactions),
+                self.format_number(stat.total_tokens.input),
+                self.format_number(stat.total_tokens.output),
+                self.format_number(stat.total_tokens.cache_write),
+                self.format_number(stat.total_tokens.cache_read),
+                self.format_number(stat.total_tokens.total),
+                Text(self.format_currency(stat.total_cost), style=cost_color),
                 Text(cost_percentage, style=cost_color),
                 speed_text
             )

--- a/ocmonitor/ui/tables.py
+++ b/ocmonitor/ui/tables.py
@@ -10,6 +10,7 @@ from rich.panel import Panel
 from ..models.session import SessionData, TokenUsage
 from ..models.analytics import DailyUsage, ModelUsageStats, ModelDetailStats
 from ..models.tool_usage import ToolUsageStats
+from ..utils.file_utils import FileProcessor
 from ..utils.time_utils import TimeUtils, compute_p50_output_rate
 from ..utils.formatting import ColorFormatter
 
@@ -47,14 +48,6 @@ class TableFormatter:
     def get_cost_color(self, cost: Decimal, quota: Optional[Decimal] = None) -> str:
         """Get color for cost based on quota using semantic theme tags."""
         return ColorFormatter.get_cost_color(cost, quota, default_style="table.row.main")
-
-    @staticmethod
-    def _split_provider_model(display_model: str) -> tuple:
-        """Split 'provider/model' into (provider, model). Bare model → ('', model)."""
-        if '/' in display_model:
-            provider, _, model = display_model.partition('/')
-            return provider, model
-        return "", display_model
 
     @staticmethod
     def _compact_models_display(models: list, max_groups: int = 3) -> str:
@@ -153,7 +146,7 @@ class TableFormatter:
                     session_display = ""
 
                 # Format model name
-                provider_name, model_name = self._split_provider_model(model)
+                provider_name, model_name = FileProcessor.split_provider_model(model)
                 provider_text = Text(provider_name[:17] + "..." if len(provider_name) > 20 else provider_name)
                 model_text = Text(model_name[:27] + "..." if len(model_name) > 30 else model_name)
 
@@ -249,7 +242,7 @@ class TableFormatter:
 
             cost_color = self.get_cost_color(cost)
 
-            prov, mod = self._split_provider_model(file.display_model)
+            prov, mod = FileProcessor.split_provider_model(file.display_model)
 
             table.add_row(
                 Text(file.file_name[:27] + "..." if len(file.file_name) > 30 else file.file_name),
@@ -384,7 +377,7 @@ class TableFormatter:
             else:
                 speed_text = f"{speed:.1f} t/s"
 
-            prov, mod = self._split_provider_model(model.model_name)
+            prov, mod = FileProcessor.split_provider_model(model.model_name)
 
             table.add_row(
                 Text(prov[:17] + "..." if len(prov) > 20 else prov),
@@ -701,4 +694,3 @@ class TableFormatter:
             )
 
         return table
-

--- a/ocmonitor/utils/currency.py
+++ b/ocmonitor/utils/currency.py
@@ -99,4 +99,5 @@ class CurrencyConverter:
             return f"{self.symbol}{formatted_amount}"
 
     def __repr__(self) -> str:
+        """Return debug representation with currency code, rate, and format."""
         return f"CurrencyConverter({self.code}, rate={self.rate}, format={self.display_format})"

--- a/ocmonitor/utils/error_handling.py
+++ b/ocmonitor/utils/error_handling.py
@@ -17,6 +17,7 @@ class OCMonitorError(Exception):
     """Base exception for OpenCode Monitor."""
 
     def __init__(self, message: str, details: Optional[Dict[str, Any]] = None):
+        """Initialize error with a message and optional structured details."""
         super().__init__(message)
         self.message = message
         self.details = details or {}
@@ -123,8 +124,11 @@ def handle_errors(error_handler: Optional[ErrorHandler] = None, context: str = "
         Decorated function
     """
     def decorator(func: F) -> F:
+        """Wrap function with centralized error handling."""
+
         @wraps(func)
         def wrapper(*args, **kwargs):
+            """Execute wrapped function and return structured success/error output."""
             handler = error_handler or ErrorHandler()
             func_context = context or f"{func.__module__}.{func.__name__}"
             return handler.safe_execute(func, *args, context=func_context, **kwargs)
@@ -404,8 +408,11 @@ def graceful_shutdown(cleanup_func: Optional[Callable] = None):
         Decorated function
     """
     def decorator(func: F) -> F:
+        """Wrap function to run cleanup on interruption or failure."""
+
         @wraps(func)
         def wrapper(*args, **kwargs):
+            """Execute wrapped function and invoke cleanup before re-raising errors."""
             try:
                 return func(*args, **kwargs)
             except KeyboardInterrupt:

--- a/ocmonitor/utils/file_utils.py
+++ b/ocmonitor/utils/file_utils.py
@@ -213,7 +213,8 @@ class FileProcessor:
         try:
             # Extract basic information
             model_id = data.get('modelID', 'unknown')
-            
+            provider_id = data.get('providerID', '').lower() or None
+
             # Handle fully qualified model names
             model_id = FileProcessor._extract_model_name(model_id)
 
@@ -254,6 +255,7 @@ class FileProcessor:
                 file_path=file_path,
                 session_id=session_id,
                 model_id=model_id,
+                provider_id=provider_id,
                 tokens=tokens,
                 time_data=time_data,
                 project_path=project_path,

--- a/ocmonitor/utils/file_utils.py
+++ b/ocmonitor/utils/file_utils.py
@@ -124,6 +124,70 @@ class FileProcessor:
         return model_id
 
     @staticmethod
+    def lookup_pricing(
+        pricing_data: Dict[str, Any], model_id: str, provider_id: Optional[str] = None
+    ) -> Optional[Any]:
+        """Lookup pricing with provider-aware, backward-compatible fallback chain.
+
+        Lookup chain (stops at first match):
+          1. provider_id/model_id            - exact provider+model match
+          2. provider_id/normalize(model_id) - provider + normalized model
+          3. model_id                         - bare exact (backward compat)
+          4. normalize(model_id)             - bare normalized (backward compat)
+          5. scan */model_id or */normalize  - any provider, model-only match
+
+        Args:
+            pricing_data: Dictionary of model pricing information
+            model_id: Raw or normalized model id
+            provider_id: Optional provider id
+
+        Returns:
+            Matched pricing object or None
+        """
+        if not pricing_data:
+            return None
+
+        raw_model = (model_id or "unknown").lower()
+        normalized = FileProcessor._normalize_model_name(raw_model)
+        provider = (provider_id or "").lower() or None
+
+        # Step 1: provider_id/model_id exact match
+        if provider:
+            key = f"{provider}/{raw_model}"
+            if key in pricing_data:
+                return pricing_data[key]
+
+        # Step 2: provider_id/normalize(model_id)
+        if provider:
+            key = f"{provider}/{normalized}"
+            if key in pricing_data:
+                return pricing_data[key]
+
+        # Step 3: bare model_id exact match (backward compat / old models.json)
+        if raw_model in pricing_data:
+            return pricing_data[raw_model]
+
+        # Step 4: bare normalized exact match (backward compat)
+        if normalized in pricing_data:
+            return pricing_data[normalized]
+
+        # Step 5: scan all keys for */model_id or */normalized
+        for key, value in pricing_data.items():
+            if not isinstance(key, str):
+                continue
+            if '/' in key:
+                _, key_model = key.split('/', 1)
+                if key_model == raw_model or key_model == normalized:
+                    return value
+            else:
+                # Existing prefix-scan for -extended variant matching
+                if key.replace('-extended', '') == normalized or \
+                   normalized.replace('-extended', '') == key:
+                    return value
+
+        return None
+
+    @staticmethod
     def extract_project_name(path_str: str) -> str:
         """Extract project name from a file path.
         
@@ -213,7 +277,7 @@ class FileProcessor:
         try:
             # Extract basic information
             model_id = data.get('modelID', 'unknown')
-            provider_id = data.get('providerID', '').lower() or None
+            provider_id = (data.get('providerID') or '').lower() or None
 
             # Handle fully qualified model names
             model_id = FileProcessor._extract_model_name(model_id)

--- a/ocmonitor/utils/file_utils.py
+++ b/ocmonitor/utils/file_utils.py
@@ -188,6 +188,14 @@ class FileProcessor:
         return None
 
     @staticmethod
+    def split_provider_model(display_model: str) -> tuple[str, str]:
+        """Split 'provider/model' into (provider, model). Bare model -> ('', model)."""
+        if '/' in display_model:
+            provider, _, model = display_model.partition('/')
+            return provider, model
+        return "", display_model
+
+    @staticmethod
     def extract_project_name(path_str: str) -> str:
         """Extract project name from a file path.
         

--- a/ocmonitor/utils/sqlite_utils.py
+++ b/ocmonitor/utils/sqlite_utils.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any, Generator
 from datetime import datetime
 
+from ..utils.file_utils import FileProcessor
 from ..models.session import SessionData, InteractionFile, TokenUsage, TimeData
 from ..models.tool_usage import ToolUsageStats, ToolUsageSummary, ModelToolUsage
 from ..models.analytics import ModelDetailStats
@@ -156,7 +157,7 @@ class SQLiteProcessor:
         project_path = cls._extract_project_path(data)
         agent = cls._extract_agent(data)
         model_id = cls._extract_model_name(data).lower()
-        provider_id = data.get("providerID", "").lower() or None
+        provider_id = (data.get("providerID") or "").lower() or None
         finish_reason = data.get("finish")
 
         return InteractionFile(
@@ -972,7 +973,11 @@ class SQLiteProcessor:
 
             # Calculate cost using pricing data
             total_cost = Decimal('0.0')
-            model_pricing = pricing_data.get(model_name)
+            model_pricing = FileProcessor.lookup_pricing(
+                pricing_data,
+                model_id=model_name,
+                provider_id=None,
+            )
             if model_pricing:
                 price_input = getattr(model_pricing, 'input', 0) or 0
                 price_output = getattr(model_pricing, 'output', 0) or 0

--- a/ocmonitor/utils/sqlite_utils.py
+++ b/ocmonitor/utils/sqlite_utils.py
@@ -442,6 +442,7 @@ class SQLiteProcessor:
     def _build_workflow_dict(
         cls, conn: sqlite3.Connection, main_session: SessionData
     ) -> Dict[str, Any]:
+        """Build workflow payload with parent session and loaded sub-agents."""
         sub_agent_rows = conn.execute(
             """
             SELECT s.*, p.worktree as project_path, p.name as project_name

--- a/ocmonitor/utils/sqlite_utils.py
+++ b/ocmonitor/utils/sqlite_utils.py
@@ -155,13 +155,15 @@ class SQLiteProcessor:
         time_data = cls._extract_time_data(data)
         project_path = cls._extract_project_path(data)
         agent = cls._extract_agent(data)
-        model_id = cls._extract_model_name(data)
+        model_id = cls._extract_model_name(data).lower()
+        provider_id = data.get("providerID", "").lower() or None
         finish_reason = data.get("finish")
 
         return InteractionFile(
             file_path=Path("sqlite") / session_id,  # Placeholder path
             session_id=session_id,
             model_id=model_id,
+            provider_id=provider_id,
             tokens=tokens,
             time_data=time_data,
             project_path=project_path,

--- a/tests/unit/test_export_service_version.py
+++ b/tests/unit/test_export_service_version.py
@@ -1,8 +1,10 @@
 """Unit tests for export metadata version reporting."""
 
 import json
+from decimal import Decimal
 from pathlib import Path
 
+from ocmonitor.models.analytics import ModelBreakdownReport, ModelUsageStats
 import ocmonitor.services.export_service as export_module
 from ocmonitor.services.export_service import ExportService
 
@@ -22,3 +24,29 @@ class TestExportServiceVersion:
 
         exported = json.loads(Path(output_path).read_text(encoding="utf-8"))
         assert exported["metadata"]["export_info"]["version"] == "9.9.9"
+
+
+class TestExportModelsBreakdown:
+    """Regression tests for model breakdown export field mapping."""
+
+    def test_models_export_maps_display_model_to_model_name_column(self, tmp_path):
+        """_extract_export_data('models') emits model_name from display_model."""
+        service = ExportService(export_dir=str(tmp_path))
+        report_data = {
+            "model_breakdown": ModelBreakdownReport(
+                timeframe="all",
+                model_stats=[
+                    ModelUsageStats(
+                        display_model="claude-sonnet-4.5",
+                        total_sessions=1,
+                        total_interactions=2,
+                        total_cost=Decimal("0.01"),
+                    )
+                ],
+            )
+        }
+
+        rows = service._extract_export_data(report_data, "models")
+
+        assert len(rows) == 1
+        assert rows[0]["model_name"] == "claude-sonnet-4.5"

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -172,6 +172,21 @@ class TestParseInteractionFile:
         result = FileProcessor.parse_interaction_file(test_file, "ses_test")
         assert result is None
 
+    def test_parse_null_provider_id(self, tmp_path):
+        """providerID=null should not crash and should map to None."""
+        test_file = tmp_path / "inter_0001.json"
+        interaction_data = {
+            "modelID": "test-model",
+            "providerID": None,
+            "tokens": {"input": 1000, "output": 500},
+        }
+        test_file.write_text(json.dumps(interaction_data))
+
+        result = FileProcessor.parse_interaction_file(test_file, "ses_test")
+
+        assert result is not None
+        assert result.provider_id is None
+
 
 class TestLoadSessionData:
     """Tests for load_session_data method."""

--- a/tests/unit/test_live_monitor.py
+++ b/tests/unit/test_live_monitor.py
@@ -1365,3 +1365,47 @@ class TestHandleNavigationCommand:
         assert workflow_id == "wf-3"
         assert workflow == workflow_3
         assert selected == "wf-3"
+
+
+class TestLiveMonitorProviderAwareRegressions:
+    """Regression tests for provider-aware pricing lookups in live monitor."""
+
+    def test_session_context_usage_uses_provider_aware_context_window(self, tmp_path):
+        """Provider/model pricing should be used instead of default context window."""
+        from decimal import Decimal
+        from ocmonitor.config import ModelPricing
+        from ocmonitor.models.session import InteractionFile, SessionData, TokenUsage
+
+        pricing_data = {
+            "github-copilot/claude-sonnet-4.5": ModelPricing(
+                input=Decimal("1.0"),
+                output=Decimal("2.0"),
+                cacheWrite=Decimal("0.0"),
+                cacheRead=Decimal("0.0"),
+                contextWindow=100000,
+                sessionQuota=Decimal("5.0"),
+            )
+        }
+
+        monitor = LiveMonitor(pricing_data=pricing_data, paths_config=PathsConfig(messages_dir=str(tmp_path)))
+
+        inter_file = tmp_path / "inter_0001.json"
+        inter_file.write_text("{}")
+        interaction = InteractionFile(
+            file_path=inter_file,
+            session_id="ses_test",
+            model_id="claude-sonnet-4.5",
+            provider_id="github-copilot",
+            tokens=TokenUsage(input=1000, output=100, cache_read=200, cache_write=300),
+            raw_data={},
+        )
+        session = SessionData(
+            session_id="ses_test",
+            session_path=tmp_path / "ses_test",
+            files=[interaction],
+        )
+
+        result = monitor._get_session_context_usage(session)
+
+        assert "claude-sonnet-4.5" in result
+        assert result["claude-sonnet-4.5"]["context_window"] == 100000

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -819,6 +819,7 @@ class TestInteractionFileDisplayModel:
     """Tests for InteractionFile.display_model provider-aware output."""
 
     def test_display_model_with_provider_returns_qualified_name(self, tmp_path):
+        """Display model includes provider when provider_id is present."""
         f = tmp_path / "inter_0001.json"
         f.write_text("{}")
 
@@ -832,6 +833,7 @@ class TestInteractionFileDisplayModel:
         assert interaction.display_model == "github-copilot/claude-sonnet-4.5"
 
     def test_display_model_without_provider_returns_bare_model(self, tmp_path):
+        """Display model falls back to bare model when provider_id is missing."""
         f = tmp_path / "inter_0002.json"
         f.write_text("{}")
 
@@ -849,6 +851,7 @@ class TestSessionDataProviderAwareModelFields:
     """Tests for provider-aware SessionData models_used and model breakdown."""
 
     def _make_file(self, tmp_path, name, model_id, provider_id=None, **tokens):
+        """Create an interaction file fixture with optional token overrides."""
         f = tmp_path / f"{name}.json"
         f.write_text("{}")
         return InteractionFile(
@@ -861,6 +864,7 @@ class TestSessionDataProviderAwareModelFields:
         )
 
     def _make_session(self, tmp_path, files):
+        """Create a session fixture with the provided interaction files."""
         session_path = tmp_path / "ses_test"
         session_path.mkdir(exist_ok=True)
         return SessionData(
@@ -870,6 +874,7 @@ class TestSessionDataProviderAwareModelFields:
         )
 
     def test_models_used_returns_provider_qualified_names(self, tmp_path):
+        """Session models_used returns provider-qualified model identifiers."""
         file_a = self._make_file(
             tmp_path, "a", model_id="model-a", provider_id="prov-a"
         )
@@ -882,6 +887,7 @@ class TestSessionDataProviderAwareModelFields:
         assert sorted(session.models_used) == ["prov-a/model-a", "prov-a/model-b"]
 
     def test_models_used_deduplicates_same_provider_and_model(self, tmp_path):
+        """Duplicate provider/model pairs are deduplicated in models_used."""
         file_a = self._make_file(
             tmp_path, "a", model_id="model-x", provider_id="prov-a"
         )
@@ -894,6 +900,7 @@ class TestSessionDataProviderAwareModelFields:
         assert session.models_used == ["prov-a/model-x"]
 
     def test_models_used_keeps_same_model_under_different_providers_distinct(self, tmp_path):
+        """Same bare model under different providers remains distinct."""
         file_a = self._make_file(
             tmp_path, "a", model_id="model-x", provider_id="prov-a"
         )
@@ -906,6 +913,7 @@ class TestSessionDataProviderAwareModelFields:
         assert sorted(session.models_used) == ["prov-a/model-x", "prov-b/model-x"]
 
     def test_model_breakdown_aggregates_same_provider_and_model(self, tmp_path):
+        """Model breakdown aggregates token totals per provider/model key."""
         file_a = self._make_file(
             tmp_path,
             "a",
@@ -932,6 +940,7 @@ class TestSessionDataProviderAwareModelFields:
         assert breakdown["openai/gpt-4o"]["tokens"].output == 130
 
     def test_model_breakdown_separates_same_model_across_providers(self, tmp_path):
+        """Model breakdown keeps identical model IDs separate by provider."""
         file_a = self._make_file(
             tmp_path, "a", model_id="gpt-4o", provider_id="prov-a", input=100
         )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -813,3 +813,135 @@ class TestPricingLookupHelperRegression:
 
         assert pricing is not None
         assert pricing.input == Decimal("1.0")
+
+
+class TestInteractionFileDisplayModel:
+    """Tests for InteractionFile.display_model provider-aware output."""
+
+    def test_display_model_with_provider_returns_qualified_name(self, tmp_path):
+        f = tmp_path / "inter_0001.json"
+        f.write_text("{}")
+
+        interaction = InteractionFile(
+            file_path=f,
+            session_id="ses_test",
+            model_id="claude-sonnet-4.5",
+            provider_id="github-copilot",
+        )
+
+        assert interaction.display_model == "github-copilot/claude-sonnet-4.5"
+
+    def test_display_model_without_provider_returns_bare_model(self, tmp_path):
+        f = tmp_path / "inter_0002.json"
+        f.write_text("{}")
+
+        interaction = InteractionFile(
+            file_path=f,
+            session_id="ses_test",
+            model_id="claude-sonnet-4.5",
+            provider_id=None,
+        )
+
+        assert interaction.display_model == "claude-sonnet-4.5"
+
+
+class TestSessionDataProviderAwareModelFields:
+    """Tests for provider-aware SessionData models_used and model breakdown."""
+
+    def _make_file(self, tmp_path, name, model_id, provider_id=None, **tokens):
+        f = tmp_path / f"{name}.json"
+        f.write_text("{}")
+        return InteractionFile(
+            file_path=f,
+            session_id="ses_test",
+            model_id=model_id,
+            provider_id=provider_id,
+            tokens=TokenUsage(**tokens) if tokens else TokenUsage(),
+            raw_data={},
+        )
+
+    def _make_session(self, tmp_path, files):
+        session_path = tmp_path / "ses_test"
+        session_path.mkdir(exist_ok=True)
+        return SessionData(
+            session_id="ses_test",
+            session_path=session_path,
+            files=files,
+        )
+
+    def test_models_used_returns_provider_qualified_names(self, tmp_path):
+        file_a = self._make_file(
+            tmp_path, "a", model_id="model-a", provider_id="prov-a"
+        )
+        file_b = self._make_file(
+            tmp_path, "b", model_id="model-b", provider_id="prov-a"
+        )
+
+        session = self._make_session(tmp_path, [file_a, file_b])
+
+        assert sorted(session.models_used) == ["prov-a/model-a", "prov-a/model-b"]
+
+    def test_models_used_deduplicates_same_provider_and_model(self, tmp_path):
+        file_a = self._make_file(
+            tmp_path, "a", model_id="model-x", provider_id="prov-a"
+        )
+        file_b = self._make_file(
+            tmp_path, "b", model_id="model-x", provider_id="prov-a"
+        )
+
+        session = self._make_session(tmp_path, [file_a, file_b])
+
+        assert session.models_used == ["prov-a/model-x"]
+
+    def test_models_used_keeps_same_model_under_different_providers_distinct(self, tmp_path):
+        file_a = self._make_file(
+            tmp_path, "a", model_id="model-x", provider_id="prov-a"
+        )
+        file_b = self._make_file(
+            tmp_path, "b", model_id="model-x", provider_id="prov-b"
+        )
+
+        session = self._make_session(tmp_path, [file_a, file_b])
+
+        assert sorted(session.models_used) == ["prov-a/model-x", "prov-b/model-x"]
+
+    def test_model_breakdown_aggregates_same_provider_and_model(self, tmp_path):
+        file_a = self._make_file(
+            tmp_path,
+            "a",
+            model_id="gpt-4o",
+            provider_id="openai",
+            input=100,
+            output=50,
+        )
+        file_b = self._make_file(
+            tmp_path,
+            "b",
+            model_id="gpt-4o",
+            provider_id="openai",
+            input=200,
+            output=80,
+        )
+
+        session = self._make_session(tmp_path, [file_a, file_b])
+        breakdown = session.get_model_breakdown({})
+
+        assert len(breakdown) == 1
+        assert "openai/gpt-4o" in breakdown
+        assert breakdown["openai/gpt-4o"]["tokens"].input == 300
+        assert breakdown["openai/gpt-4o"]["tokens"].output == 130
+
+    def test_model_breakdown_separates_same_model_across_providers(self, tmp_path):
+        file_a = self._make_file(
+            tmp_path, "a", model_id="gpt-4o", provider_id="prov-a", input=100
+        )
+        file_b = self._make_file(
+            tmp_path, "b", model_id="gpt-4o", provider_id="prov-b", input=200
+        )
+
+        session = self._make_session(tmp_path, [file_a, file_b])
+        breakdown = session.get_model_breakdown({})
+
+        assert sorted(breakdown.keys()) == ["prov-a/gpt-4o", "prov-b/gpt-4o"]
+        assert breakdown["prov-a/gpt-4o"]["tokens"].input == 100
+        assert breakdown["prov-b/gpt-4o"]["tokens"].input == 200

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -709,3 +709,107 @@ class TestReportGeneratorModelBreakdown:
         assert results[0]["interactions"] == 2
         assert results[0]["input_tokens"] == 300
         assert results[0]["output_tokens"] == 130
+
+
+class TestSessionAnalyzerProviderAwareRegressions:
+    """Regression tests for maintainer-reported provider-aware issues."""
+
+    def _make_file(self, tmp_path, name, model_id, provider_id=None, **tokens):
+        f = tmp_path / f"{name}.json"
+        f.write_text("{}")
+        return InteractionFile(
+            file_path=f,
+            session_id="ses_test",
+            model_id=model_id,
+            provider_id=provider_id,
+            tokens=TokenUsage(**tokens) if tokens else TokenUsage(),
+            raw_data={},
+        )
+
+    def test_filter_sessions_by_model_matches_bare_name_against_provider_model(self, tmp_path):
+        """Bare model filter should match provider/model display values for backward compatibility."""
+        from ocmonitor.services.session_analyzer import SessionAnalyzer
+
+        interaction = self._make_file(
+            tmp_path,
+            "inter_provider",
+            model_id="claude-sonnet-4.5",
+            provider_id="github-copilot",
+            input=10,
+            output=5,
+        )
+        session = SessionData(
+            session_id="ses_test",
+            session_path=tmp_path / "ses_test",
+            files=[interaction],
+        )
+
+        analyzer = SessionAnalyzer(pricing_data={})
+        result = analyzer.filter_sessions_by_model([session], ["claude-sonnet-4.5"])
+
+        assert len(result) == 1
+
+    def test_validate_session_health_no_false_unknown_warning_for_bare_model(self, tmp_path):
+        """Bare model should not be flagged unknown when pricing exists under provider/model key."""
+        from ocmonitor.services.session_analyzer import SessionAnalyzer
+
+        interaction = self._make_file(
+            tmp_path,
+            "inter_bare",
+            model_id="claude-sonnet-4.5",
+            provider_id=None,
+            input=10,
+            output=5,
+        )
+        session = SessionData(
+            session_id="ses_test",
+            session_path=tmp_path / "ses_test",
+            files=[interaction],
+        )
+
+        pricing_data = {
+            "github-copilot/claude-sonnet-4.5": ModelPricing(
+                input=Decimal("1.0"),
+                output=Decimal("2.0"),
+                cacheWrite=Decimal("0.0"),
+                cacheRead=Decimal("0.0"),
+                contextWindow=200000,
+                sessionQuota=Decimal("10.0"),
+            )
+        }
+        analyzer = SessionAnalyzer(pricing_data=pricing_data)
+
+        result = analyzer.validate_session_health(session)
+
+        unknown_warnings = [
+            w for w in result.get("warnings", []) if "Unknown models with no pricing" in w
+        ]
+        assert unknown_warnings == []
+
+
+class TestPricingLookupHelperRegression:
+    """Regression test to enforce shared provider-aware pricing lookup helper."""
+
+    def test_file_processor_exposes_shared_lookup_pricing_helper(self):
+        """Shared helper should exist and resolve bare model via provider/model keys."""
+        from ocmonitor.utils.file_utils import FileProcessor
+
+        pricing_data = {
+            "github-copilot/claude-sonnet-4.5": ModelPricing(
+                input=Decimal("1.0"),
+                output=Decimal("2.0"),
+                cacheWrite=Decimal("0.0"),
+                cacheRead=Decimal("0.0"),
+                contextWindow=200000,
+                sessionQuota=Decimal("10.0"),
+            )
+        }
+
+        pricing = FileProcessor.lookup_pricing(
+            pricing_data,
+            model_id="claude-sonnet-4.5",
+            provider_id=None,
+        )
+
+        assert pricing is not None
+        assert pricing.input == Decimal("1.0")

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -630,3 +630,82 @@ class TestWorkflowForceRecalculate:
         # Recalculate: (1M input + 1M output at $3/M) + (0.5M input + 0.5M output at $3/M)
         # = $3.00 + $1.50 = $4.50
         assert workflow.calculate_total_cost(pricing_data, force_recalculate=True) == Decimal("4.5")
+
+
+class TestReportGeneratorModelBreakdown:
+    """Tests for ReportGenerator._get_model_breakdown_for_sessions provider-aware grouping."""
+
+    def _make_file(self, tmp_path, session_id, name, model_id, provider_id=None, **tokens):
+        f = tmp_path / f"{name}.json"
+        f.write_text("{}")
+        return InteractionFile(
+            file_path=f,
+            session_id=session_id,
+            model_id=model_id,
+            provider_id=provider_id,
+            tokens=TokenUsage(**tokens) if tokens else TokenUsage(),
+            raw_data={},
+        )
+
+    def test_same_model_id_different_providers_are_not_merged(self, tmp_path):
+        """Two providers using the same model_id must produce two separate breakdown rows."""
+        from unittest.mock import MagicMock
+        from ocmonitor.services.report_generator import ReportGenerator
+
+        file_a = self._make_file(
+            tmp_path, "ses1", "file_a", model_id="claude-sonnet", provider_id="prov-a",
+            input=100, output=50,
+        )
+        file_b = self._make_file(
+            tmp_path, "ses1", "file_b", model_id="claude-sonnet", provider_id="prov-b",
+            input=200, output=80,
+        )
+
+        session = SessionData(
+            session_id="ses1",
+            session_path=tmp_path / "ses1",
+            files=[file_a, file_b],
+        )
+
+        analyzer = MagicMock()
+        analyzer.pricing_data = {}
+        rg = ReportGenerator(analyzer=analyzer)
+
+        results = rg._get_model_breakdown_for_sessions([session])
+
+        models_in_results = {r["model"] for r in results}
+        assert "prov-a/claude-sonnet" in models_in_results, "prov-a entry missing"
+        assert "prov-b/claude-sonnet" in models_in_results, "prov-b entry missing"
+        assert len(results) == 2, f"Expected 2 rows, got {len(results)}: {models_in_results}"
+
+    def test_same_provider_same_model_id_are_merged(self, tmp_path):
+        """Two files with the same provider+model_id must be aggregated into one row."""
+        from unittest.mock import MagicMock
+        from ocmonitor.services.report_generator import ReportGenerator
+
+        file_a = self._make_file(
+            tmp_path, "ses1", "file_c", model_id="gpt-4o", provider_id="openai",
+            input=100, output=50,
+        )
+        file_b = self._make_file(
+            tmp_path, "ses1", "file_d", model_id="gpt-4o", provider_id="openai",
+            input=200, output=80,
+        )
+
+        session = SessionData(
+            session_id="ses1",
+            session_path=tmp_path / "ses1",
+            files=[file_a, file_b],
+        )
+
+        analyzer = MagicMock()
+        analyzer.pricing_data = {}
+        rg = ReportGenerator(analyzer=analyzer)
+
+        results = rg._get_model_breakdown_for_sessions([session])
+
+        assert len(results) == 1
+        assert results[0]["model"] == "openai/gpt-4o"
+        assert results[0]["interactions"] == 2
+        assert results[0]["input_tokens"] == 300
+        assert results[0]["output_tokens"] == 130

--- a/tests/unit/test_sqlite_utils.py
+++ b/tests/unit/test_sqlite_utils.py
@@ -1,5 +1,6 @@
 """Tests for SQLite path discovery behavior."""
 
+import json
 from pathlib import Path
 
 from ocmonitor.config import Config, PathsConfig, config_manager
@@ -72,3 +73,23 @@ class TestFindDatabasePath:
         resolved = SQLiteProcessor.find_database_path()
 
         assert resolved == default_db
+
+
+class TestParseMessageData:
+    """Tests for SQLiteProcessor.parse_message_data."""
+
+    def test_parse_null_provider_id(self):
+        """providerID=null should not crash and should map to None."""
+        message = json.dumps(
+            {
+                "role": "assistant",
+                "modelID": "test-model",
+                "providerID": None,
+                "tokens": {"input": 1000, "output": 500},
+            }
+        )
+
+        result = SQLiteProcessor.parse_message_data(message, "ses_test")
+
+        assert result is not None
+        assert result.provider_id is None

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from unittest.mock import MagicMock
 
+from ocmonitor.utils.file_utils import FileProcessor
 from ocmonitor.ui.tables import TableFormatter
 
 
@@ -138,21 +139,23 @@ class TestCompactModelsDisplay:
 
 
 class TestSplitProviderModel:
-    """Tests for provider/model splitting helper in table formatter."""
+    """Tests for provider/model splitting helper in file processor."""
 
     def test_qualified_name_splits_provider_and_model(self):
-        provider, model = TableFormatter._split_provider_model(
+        provider, model = FileProcessor.split_provider_model(
             "github-copilot/claude-sonnet-4.5"
         )
         assert provider == "github-copilot"
         assert model == "claude-sonnet-4.5"
 
     def test_bare_model_returns_empty_provider(self):
-        provider, model = TableFormatter._split_provider_model("claude-sonnet-4.5")
+        provider, model = FileProcessor.split_provider_model("claude-sonnet-4.5")
         assert provider == ""
         assert model == "claude-sonnet-4.5"
 
     def test_multiple_slashes_split_on_first_only(self):
-        provider, model = TableFormatter._split_provider_model("openrouter/anthropic/claude-opus")
+        provider, model = FileProcessor.split_provider_model(
+            "openrouter/anthropic/claude-opus"
+        )
         assert provider == "openrouter"
         assert model == "anthropic/claude-opus"

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -86,3 +86,52 @@ def test_live_dashboard_parent_row_with_null_sub_agents():
 
     assert table.columns[1]._cells[0] == "200"
     assert str(table.columns[2]._cells[0]) == "$2.50"
+
+
+class TestCompactModelsDisplay:
+    """Tests for TableFormatter._compact_models_display determinism and formatting."""
+
+    def _fmt(self, models, max_groups=3):
+        return TableFormatter._compact_models_display(models, max_groups=max_groups)
+
+    def test_single_provider_single_model(self):
+        assert self._fmt(["github-copilot/claude-sonnet-4.5"]) == "github-copilot/claude-sonnet-4.5"
+
+    def test_single_bare_model(self):
+        assert self._fmt(["unknown-model"]) == "unknown-model"
+
+    def test_multi_model_same_provider(self):
+        result = self._fmt(["prov/model-b", "prov/model-a"])
+        assert result == "prov/{model-a, model-b}"
+
+    def test_multi_provider_sorted_alphabetically(self):
+        # Input order is z-first; output must be sorted by provider name.
+        result = self._fmt(["z-prov/model-x", "a-prov/model-y"])
+        assert result == "a-prov/model-y, z-prov/model-x"
+
+    def test_bare_models_sorted_alphabetically(self):
+        result = self._fmt(["zzz-bare", "aaa-bare"])
+        assert result == "aaa-bare, zzz-bare"
+
+    def test_mixed_provider_and_bare_sorted(self):
+        # Provider entries come first (sorted), then bare entries (sorted).
+        result = self._fmt(["bare-b", "z-prov/m1", "bare-a", "a-prov/m2"], max_groups=4)
+        assert result == "a-prov/m2, z-prov/m1, bare-a, bare-b"
+
+    def test_deterministic_regardless_of_input_order(self):
+        models = ["prov-b/m2", "prov-a/m1", "prov-b/m1", "prov-a/m2"]
+        import random
+        shuffled = models[:]
+        random.shuffle(shuffled)
+        assert self._fmt(models) == self._fmt(shuffled) == "prov-a/{m1, m2}, prov-b/{m1, m2}"
+
+    def test_truncation_with_plus_n_more(self):
+        result = self._fmt(["a-prov/m1", "b-prov/m2", "c-prov/m3", "d-prov/m4"], max_groups=3)
+        assert result == "a-prov/m1, b-prov/m2, c-prov/m3 (+1 more)"
+
+    def test_deduplication(self):
+        result = self._fmt(["prov/model-a", "prov/model-a", "prov/model-b"])
+        assert result == "prov/{model-a, model-b}"
+
+    def test_empty_list(self):
+        assert self._fmt([]) == ""

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -6,6 +6,7 @@ from ocmonitor.ui.tables import TableFormatter
 
 
 def test_live_dashboard_parent_row_uses_session_total_tokens():
+    """Parent row totals include main session and all sub-agent values."""
     formatter = TableFormatter()
 
     parent = MagicMock()
@@ -42,6 +43,7 @@ def test_live_dashboard_parent_row_uses_session_total_tokens():
 
 
 def test_live_dashboard_parent_row_with_no_sub_agents():
+    """Parent row totals fall back to main session when no sub-agents exist."""
     formatter = TableFormatter()
 
     parent = MagicMock()
@@ -66,6 +68,7 @@ def test_live_dashboard_parent_row_with_no_sub_agents():
 
 
 def test_live_dashboard_parent_row_with_null_sub_agents():
+    """Parent row handles null sub-agent lists without changing totals."""
     formatter = TableFormatter()
 
     parent = MagicMock()
@@ -93,33 +96,41 @@ class TestCompactModelsDisplay:
     """Tests for TableFormatter._compact_models_display determinism and formatting."""
 
     def _fmt(self, models, max_groups=3):
+        """Format compact model list using TableFormatter helper."""
         return TableFormatter._compact_models_display(models, max_groups=max_groups)
 
     def test_single_provider_single_model(self):
+        """Single provider-qualified model renders unchanged."""
         assert self._fmt(["github-copilot/claude-sonnet-4.5"]) == "github-copilot/claude-sonnet-4.5"
 
     def test_single_bare_model(self):
+        """Single bare model renders unchanged."""
         assert self._fmt(["unknown-model"]) == "unknown-model"
 
     def test_multi_model_same_provider(self):
+        """Multiple models from one provider render in grouped brace form."""
         result = self._fmt(["prov/model-b", "prov/model-a"])
         assert result == "prov/{model-a, model-b}"
 
     def test_multi_provider_sorted_alphabetically(self):
+        """Provider groups are sorted alphabetically for deterministic output."""
         # Input order is z-first; output must be sorted by provider name.
         result = self._fmt(["z-prov/model-x", "a-prov/model-y"])
         assert result == "a-prov/model-y, z-prov/model-x"
 
     def test_bare_models_sorted_alphabetically(self):
+        """Bare model names are sorted alphabetically."""
         result = self._fmt(["zzz-bare", "aaa-bare"])
         assert result == "aaa-bare, zzz-bare"
 
     def test_mixed_provider_and_bare_sorted(self):
+        """Provider groups sort first, followed by sorted bare model names."""
         # Provider entries come first (sorted), then bare entries (sorted).
         result = self._fmt(["bare-b", "z-prov/m1", "bare-a", "a-prov/m2"], max_groups=4)
         assert result == "a-prov/m2, z-prov/m1, bare-a, bare-b"
 
     def test_deterministic_regardless_of_input_order(self):
+        """Output remains stable across different input orders."""
         models = ["prov-b/m2", "prov-a/m1", "prov-b/m1", "prov-a/m2"]
         import random
         shuffled = models[:]
@@ -127,14 +138,17 @@ class TestCompactModelsDisplay:
         assert self._fmt(models) == self._fmt(shuffled) == "prov-a/{m1, m2}, prov-b/{m1, m2}"
 
     def test_truncation_with_plus_n_more(self):
+        """Long model lists truncate with a '+N more' suffix."""
         result = self._fmt(["a-prov/m1", "b-prov/m2", "c-prov/m3", "d-prov/m4"], max_groups=3)
         assert result == "a-prov/m1, b-prov/m2, c-prov/m3 (+1 more)"
 
     def test_deduplication(self):
+        """Duplicate provider/model entries are rendered once."""
         result = self._fmt(["prov/model-a", "prov/model-a", "prov/model-b"])
         assert result == "prov/{model-a, model-b}"
 
     def test_empty_list(self):
+        """Empty model list renders as empty string."""
         assert self._fmt([]) == ""
 
 
@@ -142,6 +156,7 @@ class TestSplitProviderModel:
     """Tests for provider/model splitting helper in file processor."""
 
     def test_qualified_name_splits_provider_and_model(self):
+        """Qualified model name splits into provider and model parts."""
         provider, model = FileProcessor.split_provider_model(
             "github-copilot/claude-sonnet-4.5"
         )
@@ -149,11 +164,13 @@ class TestSplitProviderModel:
         assert model == "claude-sonnet-4.5"
 
     def test_bare_model_returns_empty_provider(self):
+        """Bare model names return empty provider and unchanged model name."""
         provider, model = FileProcessor.split_provider_model("claude-sonnet-4.5")
         assert provider == ""
         assert model == "claude-sonnet-4.5"
 
     def test_multiple_slashes_split_on_first_only(self):
+        """Only the first slash is used when splitting provider/model."""
         provider, model = FileProcessor.split_provider_model(
             "openrouter/anthropic/claude-opus"
         )

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -135,3 +135,24 @@ class TestCompactModelsDisplay:
 
     def test_empty_list(self):
         assert self._fmt([]) == ""
+
+
+class TestSplitProviderModel:
+    """Tests for provider/model splitting helper in table formatter."""
+
+    def test_qualified_name_splits_provider_and_model(self):
+        provider, model = TableFormatter._split_provider_model(
+            "github-copilot/claude-sonnet-4.5"
+        )
+        assert provider == "github-copilot"
+        assert model == "claude-sonnet-4.5"
+
+    def test_bare_model_returns_empty_provider(self):
+        provider, model = TableFormatter._split_provider_model("claude-sonnet-4.5")
+        assert provider == ""
+        assert model == "claude-sonnet-4.5"
+
+    def test_multiple_slashes_split_on_first_only(self):
+        provider, model = TableFormatter._split_provider_model("openrouter/anthropic/claude-opus")
+        assert provider == "openrouter"
+        assert model == "anthropic/claude-opus"


### PR DESCRIPTION
## Motivation

In enterprise environments, the same AI model is often available through multiple providers — for example, Claude Sonnet may be accessible via a direct API provider, a cloud marketplace, or an internal AI gateway — each potentially at a different price point. Without provider context, OCMonitor cannot distinguish between these and may apply incorrect pricing or aggregate costs that should be tracked separately.

This change makes OCMonitor provider-aware so that `github-copilot/claude-sonnet-4.6` and `another-provider/claude-sonnet-4.6` are treated as distinct entries with their own pricing.

## Description

OpenCode stores both `providerID` and `modelID` per interaction. This change surfaces the provider in OCMonitor's output and aligns `models.json` keys with the same `provider/modelID` format, enabling accurate per-provider pricing.

## Changes

### Code
- Parse `providerID` from SQLite message JSON and file-based interactions
- Add `provider_id` field to `InteractionFile` (`Optional[str]`, default `None`)
- Add `display_model` computed property: returns `provider/model` when provider is known, else just `model`
- Update `models_used` and `get_model_breakdown` to group by `display_model`
- Split the single `Model` column into two separate `Provider` and `Model` columns in all table builders and report methods; `display_model` is split on the first `/`, and bare model IDs (no provider) yield an empty Provider cell
- Compact provider-grouped format for the Daily Usage Breakdown `Models` column: single model → `provider/model`, multiple models from same provider → `provider/{model1, model2}`, truncated to 3 provider-groups with `(+N more)`

### Pricing lookup chain (5 steps, fully backward compatible)
1. `provider_id/model_id` — exact provider+model match
2. `provider_id/normalize(model_id)` — provider + normalized model
3. `model_id` — bare exact match (old `models.json` files keep working)
4. `normalize(model_id)` — bare normalized
5. Scan `*/model_id` — any provider, model-only fallback

### models.json
All 42 entries migrated to `provider/modelID` format using canonical provider IDs (`anthropic`, `openai`, `google`, `xai`, `moonshotai`, `zhipuai`, `minimax`, `alibaba`, `opencode`).

**Note:** `antigravity-claude-opus-4-6-thinking` is left as a bare key — its provider is unknown. Please advise.

## Testing

Tested against 765 real OpenCode sessions. All 330 unit tests pass.

## Sample Output

### Model Usage Breakdown
![Model Usage Breakdown](https://github.com/user-attachments/assets/d4d0ee4d-c532-4922-b1ff-3f0eb9bd8de2)

### Daily Usage Breakdown
![Daily Usage Breakdown](https://github.com/user-attachments/assets/05bc2dae-3f12-4773-9b36-648d619d0c50)

### Session Workflows
![Session Workflows](https://github.com/user-attachments/assets/58b14181-f7ef-41d5-99bd-7ae15c5403b8)

## Declaration

This contribution has been tested solely for our own use cases. It may not cover all edge cases or work correctly in all environments.

[Mathias Zeller](mailto:mathias.zeller@mercedes-benz.com) employed at [Mercedes-Benz Tech Innovation GmbH](https://www.mercedes-benz-techinnovation.com/en/imprint/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider-aware model pricing: pricing lookup and reports now surface separate Provider + Model fields and accept provider-prefixed identifiers (provider/model-id), while remaining backward-compatible.

* **Documentation**
  * Updated changelog, README, manuals, contributor docs, and examples to show provider-prefixed model keys, lookup chain, and guidance for adding models.

* **Tests**
  * Added provider-aware and regression tests covering grouping, pricing lookup, table formatting, metrics labels, and null/empty provider handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->