### PR TITLE
feat(analytics): show usage and cost on the day it was actually produced

### DIFF
--- a/ocmonitor/models/analytics.py
+++ b/ocmonitor/models/analytics.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Any, Optional, Set
 from decimal import Decimal
 from pydantic import BaseModel, Field, computed_field
 from collections import defaultdict
-from .session import SessionData, TokenUsage
+from .session import SessionData, TokenUsage, InteractionFile
 from .tool_usage import ToolUsageStats, ToolUsageSummary
 
 
@@ -78,7 +78,12 @@ class WeeklyUsage(BaseModel):
     @property
     def total_sessions(self) -> int:
         """Calculate total sessions for the week."""
-        return sum(len(day.sessions) for day in self.daily_usage)
+        session_ids = {
+            session.session_id
+            for day in self.daily_usage
+            for session in day.sessions
+        }
+        return len(session_ids)
 
     @computed_field
     @property
@@ -119,7 +124,13 @@ class MonthlyUsage(BaseModel):
     @property
     def total_sessions(self) -> int:
         """Calculate total sessions for the month."""
-        return sum(week.total_sessions for week in self.weekly_usage)
+        session_ids = {
+            session.session_id
+            for week in self.weekly_usage
+            for day in week.daily_usage
+            for session in day.sessions
+        }
+        return len(session_ids)
 
     @computed_field
     @property
@@ -254,19 +265,53 @@ class TimeframeAnalyzer:
     """Analyzer for different timeframe breakdowns."""
 
     @staticmethod
+    def _interaction_date(file: InteractionFile, fallback_date: Optional[date]) -> Optional[date]:
+        """Return interaction date using interaction timestamp with fallback."""
+        if file.time_data and file.time_data.created_datetime:
+            return file.time_data.created_datetime.date()
+        return fallback_date
+
+    @staticmethod
+    def _is_in_date_range(
+        check_date: Optional[date],
+        start_date: Optional[date],
+        end_date: Optional[date],
+    ) -> bool:
+        """Check whether a date is within optional inclusive bounds."""
+        if check_date is None:
+            return False
+        if start_date and check_date < start_date:
+            return False
+        if end_date and check_date > end_date:
+            return False
+        return True
+
+    @staticmethod
     def create_daily_breakdown(sessions: List[SessionData]) -> List[DailyUsage]:
         """Create daily breakdown from sessions."""
-        daily_data = defaultdict(list)
+        daily_data = defaultdict(lambda: defaultdict(list))
+        session_refs: Dict[int, SessionData] = {}
 
         for session in sessions:
-            if session.start_time:
-                session_date = session.start_time.date()
-                daily_data[session_date].append(session)
+            session_key = id(session)
+            session_refs[session_key] = session
+            fallback_date = session.start_time.date() if session.start_time else None
 
-        return [
-            DailyUsage(date=date_key, sessions=sessions_list)
-            for date_key, sessions_list in sorted(daily_data.items())
-        ]
+            for file in session.files:
+                interaction_date = TimeframeAnalyzer._interaction_date(file, fallback_date)
+                if interaction_date is None:
+                    continue
+                daily_data[interaction_date][session_key].append(file)
+
+        daily_usage = []
+        for date_key, sessions_files in sorted(daily_data.items()):
+            sessions_list = [
+                session_refs[session_key].model_copy(update={"files": files})
+                for session_key, files in sessions_files.items()
+            ]
+            daily_usage.append(DailyUsage(date=date_key, sessions=sessions_list))
+
+        return daily_usage
 
     @staticmethod
     def create_weekly_breakdown(daily_usage: List[DailyUsage], week_start_day: int = 0) -> List[WeeklyUsage]:
@@ -331,19 +376,6 @@ class TimeframeAnalyzer:
         force_recalculate: bool = False,
     ) -> ModelBreakdownReport:
         """Create model usage breakdown."""
-        # Filter sessions by date range if specified
-        filtered_sessions = sessions
-        if start_date or end_date:
-            filtered_sessions = []
-            for session in sessions:
-                if session.start_time:
-                    session_date = session.start_time.date()
-                    if start_date and session_date < start_date:
-                        continue
-                    if end_date and session_date > end_date:
-                        continue
-                    filtered_sessions.append(session)
-
         from typing import Dict, Set
         
         # Define model stats structure with proper types
@@ -360,10 +392,27 @@ class TimeframeAnalyzer:
         
         model_data: Dict[str, ModelStats] = defaultdict(ModelStats)
 
-        for session in filtered_sessions:
-            for model in session.models_used:
-                model_files = [f for f in session.files if f.model_id == model]
-                model_stats = model_data[model]
+        for session in sessions:
+            if start_date or end_date:
+                fallback_date = session.start_time.date() if session.start_time else None
+                filtered_files = [
+                    file
+                    for file in session.files
+                    if TimeframeAnalyzer._is_in_date_range(
+                        TimeframeAnalyzer._interaction_date(file, fallback_date),
+                        start_date,
+                        end_date,
+                    )
+                ]
+            else:
+                filtered_files = list(session.files)
+
+            if not filtered_files:
+                continue
+
+            for model_name in {file.model_id for file in filtered_files}:
+                model_files = [f for f in filtered_files if f.model_id == model_name]
+                model_stats = model_data[model_name]
 
                 # Update token counts
                 for file in model_files:
@@ -385,13 +434,31 @@ class TimeframeAnalyzer:
                 model_stats.sessions.add(session.session_id)
 
                 # Update first/last used times
-                if session.start_time:
-                    if model_stats.first_used is None or session.start_time < model_stats.first_used:
-                        model_stats.first_used = session.start_time
+                model_start_times = [
+                    file.time_data.created_datetime
+                    for file in model_files
+                    if file.time_data and file.time_data.created_datetime
+                ]
+                model_end_times = [
+                    file.time_data.completed_datetime
+                    for file in model_files
+                    if file.time_data and file.time_data.completed_datetime
+                ]
 
-                if session.end_time:
-                    if model_stats.last_used is None or session.end_time > model_stats.last_used:
-                        model_stats.last_used = session.end_time
+                model_first = min(model_start_times) if model_start_times else (
+                    session.start_time if model_files else None
+                )
+                model_last = max(model_end_times) if model_end_times else (
+                    session.start_time if model_files else None
+                )
+
+                if model_first:
+                    if model_stats.first_used is None or model_first < model_stats.first_used:
+                        model_stats.first_used = model_first
+
+                if model_last:
+                    if model_stats.last_used is None or model_last > model_stats.last_used:
+                        model_stats.last_used = model_last
 
         # Convert to ModelUsageStats objects
         model_stats_list = []
@@ -428,24 +495,11 @@ class TimeframeAnalyzer:
         force_recalculate: bool = False,
     ) -> 'ProjectBreakdownReport':
         """Create project usage breakdown."""
-        # Filter sessions by date range if specified
-        filtered_sessions = sessions
-        if start_date or end_date:
-            filtered_sessions = []
-            for session in sessions:
-                if session.start_time:
-                    session_date = session.start_time.date()
-                    if start_date and session_date < start_date:
-                        continue
-                    if end_date and session_date > end_date:
-                        continue
-                    filtered_sessions.append(session)
-
         # Define project stats structure with proper types
         class ProjectStats:
             def __init__(self):
                 self.tokens = TokenUsage()
-                self.sessions = 0
+                self.sessions: Set[str] = set()
                 self.interactions = 0
                 self.cost = Decimal('0.0')
                 self.models_used: Set[str] = set()
@@ -454,32 +508,72 @@ class TimeframeAnalyzer:
         
         project_data: Dict[str, ProjectStats] = defaultdict(ProjectStats)
 
-        for session in filtered_sessions:
-            project_name = session.project_name or "Unknown"
-            project_stats = project_data[project_name]
-            
-            # Update aggregated data
-            session_tokens = session.total_tokens
-            project_stats.tokens.input += session_tokens.input
-            project_stats.tokens.output += session_tokens.output
-            project_stats.tokens.cache_write += session_tokens.cache_write
-            project_stats.tokens.cache_read += session_tokens.cache_read
-            
-            project_stats.sessions += 1
-            project_stats.interactions += session.interaction_count
-            project_stats.cost += session.calculate_total_cost(pricing_data, force_recalculate)
-            project_stats.models_used.update(session.models_used)
-            
-            # Track first/last activity times
-            if session.start_time:
-                if (project_stats.first_activity is None or 
-                    session.start_time < project_stats.first_activity):
-                    project_stats.first_activity = session.start_time
-                    
-            if session.end_time:
-                if (project_stats.last_activity is None or 
-                    session.end_time > project_stats.last_activity):
-                    project_stats.last_activity = session.end_time
+        for session in sessions:
+            if start_date or end_date:
+                fallback_date = session.start_time.date() if session.start_time else None
+                filtered_files = [
+                    file
+                    for file in session.files
+                    if TimeframeAnalyzer._is_in_date_range(
+                        TimeframeAnalyzer._interaction_date(file, fallback_date),
+                        start_date,
+                        end_date,
+                    )
+                ]
+            else:
+                filtered_files = list(session.files)
+
+            if not filtered_files:
+                continue
+
+            project_files: Dict[str, List[InteractionFile]] = defaultdict(list)
+            for file in filtered_files:
+                project_files[file.project_name].append(file)
+
+            for project_name, files in project_files.items():
+                project_stats = project_data[project_name]
+
+                for file in files:
+                    project_stats.tokens.input += file.tokens.input
+                    project_stats.tokens.output += file.tokens.output
+                    project_stats.tokens.cache_write += file.tokens.cache_write
+                    project_stats.tokens.cache_read += file.tokens.cache_read
+
+                project_stats.sessions.add(session.session_id)
+                project_stats.interactions += len(files)
+                project_stats.cost += sum(
+                    (file.calculate_cost(pricing_data, force_recalculate) for file in files),
+                    Decimal('0.0'),
+                )
+                project_stats.models_used.update(file.model_id for file in files)
+
+                session_start_times = [
+                    file.time_data.created_datetime
+                    for file in files
+                    if file.time_data and file.time_data.created_datetime
+                ]
+                session_end_times = [
+                    file.time_data.completed_datetime
+                    for file in files
+                    if file.time_data and file.time_data.completed_datetime
+                ]
+
+                session_first = min(session_start_times) if session_start_times else (
+                    session.start_time if files else None
+                )
+                session_last = max(session_end_times) if session_end_times else (
+                    session.start_time if files else None
+                )
+
+                if session_first:
+                    if (project_stats.first_activity is None or
+                        session_first < project_stats.first_activity):
+                        project_stats.first_activity = session_first
+
+                if session_last:
+                    if (project_stats.last_activity is None or
+                        session_last > project_stats.last_activity):
+                        project_stats.last_activity = session_last
 
         # Convert to ProjectUsageStats objects
         project_stats = []
@@ -487,7 +581,7 @@ class TimeframeAnalyzer:
             project_stats.append(ProjectUsageStats(
                 project_name=project_name,
                 total_tokens=stats.tokens,
-                total_sessions=stats.sessions,
+                total_sessions=len(stats.sessions),
                 total_interactions=stats.interactions,
                 total_cost=stats.cost,
                 models_used=list(stats.models_used),

--- a/ocmonitor/services/session_analyzer.py
+++ b/ocmonitor/services/session_analyzer.py
@@ -243,10 +243,24 @@ class SessionAnalyzer:
 
         filtered = []
         for session in sessions:
-            if session.start_time:
-                session_date = session.start_time.date()
-                if TimeUtils.date_in_range(session_date, start_date, end_date):
-                    filtered.append(session)
+            fallback_date = session.start_time.date() if session.start_time else None
+            matching_files = []
+
+            for file in session.files:
+                interaction_date = TimeframeAnalyzer._interaction_date(file, fallback_date)
+                if interaction_date and TimeUtils.date_in_range(interaction_date, start_date, end_date):
+                    matching_files.append(file)
+
+            if matching_files:
+                filtered.append(session.model_copy(update={"files": matching_files}))
+                continue
+
+            if not session.files and fallback_date and TimeUtils.date_in_range(
+                fallback_date,
+                start_date,
+                end_date,
+            ):
+                filtered.append(session)
 
         return filtered
 

--- a/ocmonitor/utils/file_utils.py
+++ b/ocmonitor/utils/file_utils.py
@@ -212,7 +212,7 @@ class FileProcessor:
 
         try:
             # Extract basic information
-            model_id = data.get('modelID', 'unknown')
+            model_id = data.get('modelID') or 'unknown'
             
             # Handle fully qualified model names
             model_id = FileProcessor._extract_model_name(model_id)

--- a/ocmonitor/utils/sqlite_utils.py
+++ b/ocmonitor/utils/sqlite_utils.py
@@ -82,10 +82,10 @@ class SQLiteProcessor:
         if isinstance(model_data, dict):
             # Try modelID directly
             if "modelID" in model_data:
-                return model_data["modelID"]
+                return model_data["modelID"] or "unknown"
             # Try nested model.modelID
             if "model" in model_data and isinstance(model_data["model"], dict):
-                return model_data["model"].get("modelID", "unknown")
+                return model_data["model"].get("modelID") or "unknown"
         return "unknown"
 
     @staticmethod

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -149,6 +149,20 @@ class TestParseInteractionFile:
         
         assert result is not None
         assert result.model_id == "unknown"
+
+    def test_parse_null_model_id(self, tmp_path):
+        """Test parsing interaction with null modelID."""
+        test_file = tmp_path / "inter_0001.json"
+        interaction_data = {
+            "modelID": None,
+            "tokens": {"input": 1000, "output": 500},
+        }
+        test_file.write_text(json.dumps(interaction_data))
+
+        result = FileProcessor.parse_interaction_file(test_file, "ses_test")
+
+        assert result is not None
+        assert result.model_id == "unknown"
     
     def test_parse_missing_tokens(self, tmp_path):
         """Test parsing interaction without tokens."""

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -3,7 +3,7 @@
 import pytest
 from pathlib import Path
 from decimal import Decimal
-from datetime import datetime
+from datetime import datetime, date
 
 from ocmonitor.models.session import TokenUsage, TimeData, InteractionFile, SessionData
 from ocmonitor.config import ModelPricing
@@ -630,3 +630,388 @@ class TestWorkflowForceRecalculate:
         # Recalculate: (1M input + 1M output at $3/M) + (0.5M input + 0.5M output at $3/M)
         # = $3.00 + $1.50 = $4.50
         assert workflow.calculate_total_cost(pricing_data, force_recalculate=True) == Decimal("4.5")
+
+
+class TestInteractionDateAttribution:
+    """Tests interaction-date-based aggregation and filtering behavior."""
+
+    @pytest.fixture
+    def pricing_data(self):
+        """Provide simple pricing for aggregation tests."""
+        return {
+            "known-model": ModelPricing(
+                input=Decimal("1.0"),
+                output=Decimal("2.0"),
+                cacheWrite=Decimal("0.0"),
+                cacheRead=Decimal("0.0"),
+                contextWindow=128000,
+                sessionQuota=Decimal("0.0"),
+            )
+        }
+
+    def _make_file(self, tmp_path, name, created_dt, input_tokens, output_tokens=0):
+        """Create an interaction file with timestamp and token usage."""
+        f = tmp_path / f"{name}.json"
+        f.write_text("{}")
+        return InteractionFile(
+            file_path=f,
+            session_id="ses_multi",
+            model_id="known-model",
+            tokens=TokenUsage(input=input_tokens, output=output_tokens),
+            time_data=TimeData(created=int(created_dt.timestamp() * 1000)),
+        )
+
+    def test_daily_breakdown_splits_one_session_across_interaction_dates(self, tmp_path):
+        """Daily usage should split a multi-day session by interaction date."""
+        from ocmonitor.models.analytics import TimeframeAnalyzer
+
+        day_one = datetime(2026, 5, 1, 9, 0, 0)
+        day_two = datetime(2026, 5, 2, 10, 30, 0)
+
+        session = SessionData(
+            session_id="ses_multi",
+            session_path=tmp_path / "ses_multi",
+            files=[
+                self._make_file(tmp_path, "inter_day1", day_one, 100),
+                self._make_file(tmp_path, "inter_day2", day_two, 200),
+            ],
+        )
+
+        daily = TimeframeAnalyzer.create_daily_breakdown([session])
+
+        assert [d.date for d in daily] == [date(2026, 5, 1), date(2026, 5, 2)]
+        assert [d.total_interactions for d in daily] == [1, 1]
+        assert [d.total_tokens.input for d in daily] == [100, 200]
+
+    def test_weekly_and_monthly_total_sessions_are_unique_across_split_days(self, tmp_path):
+        """Weekly and monthly session totals should not double count a split session."""
+        from ocmonitor.models.analytics import TimeframeAnalyzer
+
+        day_one = datetime(2026, 5, 1, 9, 0, 0)
+        day_two = datetime(2026, 5, 2, 10, 30, 0)
+
+        session = SessionData(
+            session_id="ses_multi",
+            session_path=tmp_path / "ses_multi",
+            files=[
+                self._make_file(tmp_path, "inter_week_day1", day_one, 100),
+                self._make_file(tmp_path, "inter_week_day2", day_two, 200),
+            ],
+        )
+
+        daily = TimeframeAnalyzer.create_daily_breakdown([session])
+        weekly = TimeframeAnalyzer.create_weekly_breakdown(daily)
+        monthly = TimeframeAnalyzer.create_monthly_breakdown(weekly)
+
+        assert len(weekly) == 1
+        assert weekly[0].total_sessions == 1
+        assert len(monthly) == 1
+        assert monthly[0].total_sessions == 1
+
+    def test_model_breakdown_filters_by_interaction_date_not_session_start(self, tmp_path, pricing_data):
+        """Model breakdown should include only interactions in the date window."""
+        from ocmonitor.models.analytics import TimeframeAnalyzer
+
+        old_day = datetime(2026, 5, 30, 8, 0, 0)
+        in_window_day = datetime(2026, 6, 2, 14, 0, 0)
+
+        session = SessionData(
+            session_id="ses_multi",
+            session_path=tmp_path / "ses_multi",
+            files=[
+                self._make_file(tmp_path, "inter_old", old_day, 300),
+                self._make_file(tmp_path, "inter_in_window", in_window_day, 700),
+            ],
+        )
+
+        report = TimeframeAnalyzer.create_model_breakdown(
+            [session],
+            pricing_data,
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 7),
+        )
+
+        assert len(report.model_stats) == 1
+        assert report.model_stats[0].total_interactions == 1
+        assert report.model_stats[0].total_tokens.input == 700
+
+    def test_project_breakdown_filters_by_interaction_date_not_session_start(self, tmp_path, pricing_data):
+        """Project breakdown should count only in-window interactions and cost."""
+        from ocmonitor.models.analytics import TimeframeAnalyzer
+
+        old_day = datetime(2026, 5, 30, 8, 0, 0)
+        in_window_day = datetime(2026, 6, 2, 14, 0, 0)
+
+        session = SessionData(
+            session_id="ses_multi",
+            session_path=tmp_path / "ses_multi",
+            files=[
+                self._make_file(tmp_path, "project_old", old_day, 300),
+                self._make_file(tmp_path, "project_in_window", in_window_day, 700),
+            ],
+        )
+
+        report = TimeframeAnalyzer.create_project_breakdown(
+            [session],
+            pricing_data,
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 7),
+        )
+
+        assert len(report.project_stats) == 1
+        assert report.project_stats[0].total_interactions == 1
+        assert report.project_stats[0].total_tokens.input == 700
+        assert report.project_stats[0].total_cost == Decimal("0.0007")
+
+    def test_project_breakdown_buckets_filtered_files_by_file_project(self, tmp_path, pricing_data):
+        """Project breakdown should bucket filtered interactions by each file's project path."""
+        from ocmonitor.models.analytics import TimeframeAnalyzer
+
+        in_window_day = datetime(2026, 6, 2, 14, 0, 0)
+
+        a_file = self._make_file(tmp_path, "project_a", in_window_day, 300)
+        b_file = self._make_file(tmp_path, "project_b", in_window_day, 700)
+        a_file.project_path = "/workspace/project-a"
+        b_file.project_path = "/workspace/project-b"
+
+        session = SessionData(
+            session_id="ses_multi_project",
+            session_path=tmp_path / "ses_multi_project",
+            files=[a_file, b_file],
+        )
+
+        report = TimeframeAnalyzer.create_project_breakdown(
+            [session],
+            pricing_data,
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 7),
+        )
+
+        assert len(report.project_stats) == 2
+        by_project = {p.project_name: p for p in report.project_stats}
+        assert by_project["project-a"].total_tokens.input == 300
+        assert by_project["project-a"].total_interactions == 1
+        assert by_project["project-a"].total_sessions == 1
+        assert by_project["project-b"].total_tokens.input == 700
+        assert by_project["project-b"].total_interactions == 1
+        assert by_project["project-b"].total_sessions == 1
+
+    def test_model_last_used_does_not_fall_back_to_unfiltered_session_end(self, tmp_path, pricing_data):
+        """Model last_used should not leak end time from unrelated filtered files."""
+        from ocmonitor.models.analytics import TimeframeAnalyzer
+
+        model_a_created = datetime(2026, 6, 2, 10, 0, 0)
+        model_b_created = datetime(2026, 6, 2, 23, 0, 0)
+        model_b_completed = datetime(2026, 6, 2, 23, 5, 0)
+
+        file_a = self._make_file(tmp_path, "model_a", model_a_created, 100)
+        file_b = self._make_file(tmp_path, "model_b", model_b_created, 200)
+        file_b.model_id = "other-model"
+        file_b.time_data = TimeData(
+            created=int(model_b_created.timestamp() * 1000),
+            completed=int(model_b_completed.timestamp() * 1000),
+        )
+
+        session = SessionData(
+            session_id="ses_model_last_used",
+            session_path=tmp_path / "ses_model_last_used",
+            files=[file_a, file_b],
+        )
+
+        report = TimeframeAnalyzer.create_model_breakdown(
+            [session],
+            pricing_data,
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 7),
+        )
+
+        by_model = {m.model_name: m for m in report.model_stats}
+        assert by_model["known-model"].last_used == session.start_time
+        assert by_model["known-model"].last_used != session.end_time
+
+    def test_model_times_fall_back_to_session_start_when_file_timestamps_missing(self, tmp_path, pricing_data):
+        """Model first/last used should fall back to session start for timestamp-less files."""
+        from ocmonitor.models.analytics import TimeframeAnalyzer
+
+        anchor_created = datetime(2026, 6, 2, 9, 0, 0)
+        anchor_completed = datetime(2026, 6, 2, 9, 5, 0)
+
+        missing = tmp_path / "model_missing_time.json"
+        missing.write_text("{}")
+        file_missing = InteractionFile(
+            file_path=missing,
+            session_id="ses_model_fallback",
+            model_id="known-model",
+            tokens=TokenUsage(input=100),
+            time_data=None,
+        )
+
+        file_anchor = self._make_file(tmp_path, "model_anchor", anchor_created, 1)
+        file_anchor.model_id = "other-model"
+        file_anchor.time_data = TimeData(
+            created=int(anchor_created.timestamp() * 1000),
+            completed=int(anchor_completed.timestamp() * 1000),
+        )
+
+        session = SessionData(
+            session_id="ses_model_fallback",
+            session_path=tmp_path / "ses_model_fallback",
+            files=[file_missing, file_anchor],
+        )
+
+        report = TimeframeAnalyzer.create_model_breakdown(
+            [session],
+            pricing_data,
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 7),
+        )
+
+        by_model = {m.model_name: m for m in report.model_stats}
+        assert by_model["known-model"].first_used == session.start_time
+        assert by_model["known-model"].last_used == session.start_time
+
+    def test_project_last_activity_does_not_fall_back_to_unfiltered_session_end(self, tmp_path, pricing_data):
+        """Project last_activity should not leak end time from other project files."""
+        from ocmonitor.models.analytics import TimeframeAnalyzer
+
+        project_a_created = datetime(2026, 6, 2, 10, 0, 0)
+        project_b_created = datetime(2026, 6, 2, 23, 0, 0)
+        project_b_completed = datetime(2026, 6, 2, 23, 5, 0)
+
+        file_a = self._make_file(tmp_path, "project_last_a", project_a_created, 100)
+        file_b = self._make_file(tmp_path, "project_last_b", project_b_created, 200)
+        file_a.project_path = "/workspace/project-a"
+        file_b.project_path = "/workspace/project-b"
+        file_b.time_data = TimeData(
+            created=int(project_b_created.timestamp() * 1000),
+            completed=int(project_b_completed.timestamp() * 1000),
+        )
+
+        session = SessionData(
+            session_id="ses_project_last",
+            session_path=tmp_path / "ses_project_last",
+            files=[file_a, file_b],
+        )
+
+        report = TimeframeAnalyzer.create_project_breakdown(
+            [session],
+            pricing_data,
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 7),
+        )
+
+        by_project = {p.project_name: p for p in report.project_stats}
+        assert by_project["project-a"].last_activity == session.start_time
+        assert by_project["project-a"].last_activity != session.end_time
+
+    def test_project_times_fall_back_to_session_start_when_file_timestamps_missing(self, tmp_path, pricing_data):
+        """Project first/last activity should fall back to session start for timestamp-less files."""
+        from ocmonitor.models.analytics import TimeframeAnalyzer
+
+        anchor_created = datetime(2026, 6, 2, 9, 0, 0)
+        anchor_completed = datetime(2026, 6, 2, 9, 5, 0)
+
+        missing = tmp_path / "project_missing_time.json"
+        missing.write_text("{}")
+        file_missing = InteractionFile(
+            file_path=missing,
+            session_id="ses_project_fallback",
+            model_id="known-model",
+            tokens=TokenUsage(input=100),
+            project_path="/workspace/project-a",
+            time_data=None,
+        )
+
+        file_anchor = self._make_file(tmp_path, "project_anchor", anchor_created, 1)
+        file_anchor.project_path = "/workspace/project-b"
+        file_anchor.time_data = TimeData(
+            created=int(anchor_created.timestamp() * 1000),
+            completed=int(anchor_completed.timestamp() * 1000),
+        )
+
+        session = SessionData(
+            session_id="ses_project_fallback",
+            session_path=tmp_path / "ses_project_fallback",
+            files=[file_missing, file_anchor],
+        )
+
+        report = TimeframeAnalyzer.create_project_breakdown(
+            [session],
+            pricing_data,
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 7),
+        )
+
+        by_project = {p.project_name: p for p in report.project_stats}
+        assert by_project["project-a"].first_activity == session.start_time
+        assert by_project["project-a"].last_activity == session.start_time
+
+    def test_filter_sessions_by_date_keeps_only_in_window_interactions(self, tmp_path):
+        """Session date filter should retain only interactions that match the date range."""
+        from ocmonitor.services.session_analyzer import SessionAnalyzer
+
+        old_day = datetime(2026, 5, 30, 8, 0, 0)
+        in_window_day = datetime(2026, 6, 2, 14, 0, 0)
+
+        session = SessionData(
+            session_id="ses_multi",
+            session_path=tmp_path / "ses_multi",
+            files=[
+                self._make_file(tmp_path, "filter_old", old_day, 300),
+                self._make_file(tmp_path, "filter_in_window", in_window_day, 700),
+            ],
+        )
+
+        analyzer = SessionAnalyzer(pricing_data={})
+        filtered = analyzer.filter_sessions_by_date(
+            [session],
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 7),
+        )
+
+        assert len(filtered) == 1
+        assert len(filtered[0].files) == 1
+        assert filtered[0].files[0].tokens.input == 700
+
+    def test_filter_sessions_by_date_falls_back_to_session_start_for_missing_timestamps(self, tmp_path):
+        """Date filtering should fall back to session start when interaction timestamp is missing."""
+        from ocmonitor.services.session_analyzer import SessionAnalyzer
+
+        in_window_day = datetime(2026, 6, 2, 14, 0, 0)
+        session_start = int(in_window_day.timestamp() * 1000)
+
+        f1 = tmp_path / "missing_time.json"
+        f2 = tmp_path / "session_anchor.json"
+        f1.write_text("{}")
+        f2.write_text("{}")
+
+        session = SessionData(
+            session_id="ses_missing",
+            session_path=tmp_path / "ses_missing",
+            files=[
+                InteractionFile(
+                    file_path=f1,
+                    session_id="ses_missing",
+                    model_id="known-model",
+                    tokens=TokenUsage(input=10),
+                    time_data=None,
+                ),
+                InteractionFile(
+                    file_path=f2,
+                    session_id="ses_missing",
+                    model_id="known-model",
+                    tokens=TokenUsage(input=1),
+                    time_data=TimeData(created=session_start),
+                ),
+            ],
+        )
+
+        analyzer = SessionAnalyzer(pricing_data={})
+        filtered = analyzer.filter_sessions_by_date(
+            [session],
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 7),
+        )
+
+        assert len(filtered) == 1
+        assert len(filtered[0].files) == 2

--- a/tests/unit/test_sqlite_utils.py
+++ b/tests/unit/test_sqlite_utils.py
@@ -1,5 +1,6 @@
 """Tests for SQLite path discovery behavior."""
 
+import json
 from pathlib import Path
 
 from ocmonitor.config import Config, PathsConfig, config_manager
@@ -72,3 +73,27 @@ class TestFindDatabasePath:
         resolved = SQLiteProcessor.find_database_path()
 
         assert resolved == default_db
+
+
+class TestParseMessageData:
+    """Tests for SQLiteProcessor.parse_message_data."""
+
+    def test_null_model_id_falls_back_to_unknown(self):
+        """Null modelID in SQLite message payload should not break parsing."""
+        message_data = json.dumps({"role": "assistant", "modelID": None})
+
+        interaction = SQLiteProcessor.parse_message_data(message_data, "ses_test")
+
+        assert interaction is not None
+        assert interaction.model_id == "unknown"
+
+    def test_nested_null_model_id_falls_back_to_unknown(self):
+        """Null nested model.modelID in SQLite payload should fall back to unknown."""
+        message_data = json.dumps(
+            {"role": "assistant", "model": {"modelID": None}}
+        )
+
+        interaction = SQLiteProcessor.parse_message_data(message_data, "ses_test")
+
+        assert interaction is not None
+        assert interaction.model_id == "unknown"


### PR DESCRIPTION
## Proposal

When I look at the daily breakdown for a given date, my intuition is simple: I want to see the cost and token usage I produced on that day — the interactions I actually had, the prompts I sent, the completions I received.

Currently that is not what the report shows. If a session was started on May 30 and I kept using it through June 2, all of its cost is attributed to May 30 — the day the session was opened — regardless of when the work actually happened. A busy June 2 can look like zero spend, while May 30 appears inflated.

The same disconnect affects the `models` and `projects` breakdowns when filtered by date range: sessions are included or excluded based on their start date, not on whether any interactions actually fell within the window.

## What I Expect

- The daily report for June 2 shows exactly the interactions, tokens, and cost that occurred on June 2.
- The weekly and monthly reports reflect what was produced during that week or month, not which sessions happened to open during it.
- Filtering by `--start-date` / `--end-date` in the model and project breakdowns includes any interaction that falls in the range and excludes any that does not — regardless of when the parent session was created.

## What This PR Does

- `create_daily_breakdown` now bins each interaction by its own timestamp, not by session start date. Multi-day sessions are split naturally across the days they span.
- `filter_sessions_by_date` clips sessions to only their in-range interactions, so downstream aggregations see the right slice.
- `create_model_breakdown` and `create_project_breakdown` apply the same interaction-level date filter when a date window is requested.
- For interactions with no timestamp, the session start date is used as a fallback, preserving existing behaviour.

## Tests Added

`TestInteractionDateAttribution` in `tests/unit/test_models.py` covers multi-day session splitting, date-window filtering in model and project breakdowns, session clipping in `filter_sessions_by_date`, and the missing-timestamp fallback.

[Mathias Zeller](mailto:mathias.zeller@mercedes-benz.com) employed at [Mercedes-Benz Tech Innovation GmbH](https://www.mercedes-benz-techinnovation.com/en/imprint/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics now attribute interactions by per-file interaction dates for daily, model, and project reports; per-file date filtering prevents time leakage and ensures correct first/last activity and unique weekly/monthly session counts.
  * Session filtering now operates at the interaction level (with session-date fallbacks) so only in-window interactions are kept.
  * Missing/null model IDs are normalized to "unknown" in parsed data.

* **Tests**
  * Added tests covering interaction-date attribution, session splitting, date-based filtering, and null-model handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->