### PR TITLE
feat: enhance live dashboard token details

### DIFF
--- a/ocmonitor.sh
+++ b/ocmonitor.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+if [[ ! -d .venv ]]; then
+  python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+
+if [[ ! -x .venv/bin/ocmonitor || "${OCMONITOR_REINSTALL:-0}" == "1" ]]; then
+  python -m pip install -e .
+fi
+
+if [[ "${OCMONITOR_WRAPPER_DEBUG:-0}" == "1" ]]; then
+  which ocmonitor
+  python - <<'PY'
+import ocmonitor.ui.dashboard as dashboard
+print(f"dashboard.py: {dashboard.__file__}")
+PY
+fi
+
+exec ocmonitor "$@"

--- a/ocmonitor/models/tool_usage.py
+++ b/ocmonitor/models/tool_usage.py
@@ -6,10 +6,15 @@ from pydantic import BaseModel, computed_field
 
 class ToolUsageStats(BaseModel):
     """Statistics for a single tool's usage."""
+
     tool_name: str
     total_calls: int = 0
     success_count: int = 0
     failure_count: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
 
     @computed_field
     @property
@@ -19,9 +24,21 @@ class ToolUsageStats(BaseModel):
             return 0.0
         return (self.success_count / self.total_calls) * 100.0
 
+    @computed_field
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens attributed to this tool."""
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_read_tokens
+            + self.cache_write_tokens
+        )
+
 
 class ToolUsageSummary(BaseModel):
     """Summary of all tool usage across sessions."""
+
     tool_stats: List[ToolUsageStats] = []
 
     @computed_field
@@ -50,9 +67,16 @@ class ToolUsageSummary(BaseModel):
             return 0.0
         return (self.total_success / self.total_calls) * 100.0
 
+    @computed_field
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens attributed across all tools."""
+        return sum(t.total_tokens for t in self.tool_stats)
+
 
 class ModelToolUsage(BaseModel):
     """Tool usage statistics grouped by model."""
+
     model_name: str
     tool_stats: List[ToolUsageStats] = []
 
@@ -61,3 +85,9 @@ class ModelToolUsage(BaseModel):
     def total_calls(self) -> int:
         """Total tool calls for this model."""
         return sum(t.total_calls for t in self.tool_stats)
+
+    @computed_field
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens attributed to tools for this model."""
+        return sum(t.total_tokens for t in self.tool_stats)

--- a/ocmonitor/ui/dashboard.py
+++ b/ocmonitor/ui/dashboard.py
@@ -11,7 +11,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from ..models.session import SessionData
+from ..models.session import SessionData, TokenUsage
 from ..models.tool_usage import ToolUsageStats, ModelToolUsage
 from ..models.workflow import SessionWorkflow
 from ..utils.formatting import ColorFormatter
@@ -36,6 +36,33 @@ class DashboardUI:
         if self.currency_converter:
             return self.currency_converter.format(amount)
         return f"${amount:.2f}"
+
+    def _fmt_compact_count(self, value: float) -> str:
+        """Format a count compactly for dense dashboard rows."""
+        abs_value = abs(value)
+        if abs_value >= 1_000_000:
+            formatted = f"{value / 1_000_000:.1f}M"
+        elif abs_value >= 1_000:
+            formatted = f"{value / 1_000:.1f}k"
+        else:
+            formatted = f"{value:.0f}"
+        return formatted.replace(".0M", "M").replace(".0k", "k")
+
+    def _format_tool_token_suffix(self, stat: ToolUsageStats) -> str:
+        """Format compact attributed per-tool token details for a tool row."""
+        if stat.total_tokens <= 0:
+            return ""
+
+        avg_tokens = stat.total_tokens / stat.total_calls if stat.total_calls else 0.0
+
+        return (
+            f"  [metric.tokens]{self._fmt_compact_count(stat.total_tokens)}[/metric.tokens] tok"
+            f" avg [metric.value]{self._fmt_compact_count(avg_tokens)}[/metric.value]/call"
+            f" · I [metric.value]{self._fmt_compact_count(stat.input_tokens)}[/metric.value]"
+            f" O [metric.value]{self._fmt_compact_count(stat.output_tokens)}[/metric.value]"
+            f" CR [metric.value]{self._fmt_compact_count(stat.cache_read_tokens)}[/metric.value]"
+            f" CW [metric.value]{self._fmt_compact_count(stat.cache_write_tokens)}[/metric.value]"
+        )
 
     def create_header(
         self,
@@ -176,20 +203,24 @@ class DashboardUI:
         model_lines = []
         for model, stats in model_breakdown.items():
             model_name = model[:35] + "..." if len(model) > 38 else model
-            
+
             # Get context usage for this model
             context_info = per_model_context.get(model, {})
             context_pct = context_info.get("usage_percentage", 0.0)
             context_bar = self.create_compact_progress_bar(context_pct, 8)
-            
+
             # Get output rate for this model
             output_rate = per_model_output_rates.get(model, 0.0)
             rate_str = f" - {output_rate:.1f} tok/s" if output_rate > 0 else ""
-            
+
             model_lines.append(
-                f"[metric.label]{model_name}[/metric.label]  -  "
-                f"[metric.value]{stats['tokens'].total:,}[/metric.value] [metric.tokens]tok[/metric.tokens]  "
-                f"[metric.cost]{self._fmt_cost(stats['cost'])}[/metric.cost]  -  "
+                f"[metric.label]{model_name}[/metric.label]\n"
+                f"  └─ Tokens: [metric.value]{stats['tokens'].total:,}[/metric.value] tok "
+                f"(In: [metric.value]{stats['tokens'].input:,}[/metric.value] | "
+                f"Out: [metric.value]{stats['tokens'].output:,}[/metric.value] | "
+                f"CW: [metric.value]{stats['tokens'].cache_write:,}[/metric.value] | "
+                f"CR: [metric.value]{stats['tokens'].cache_read:,}[/metric.value])\n"
+                f"  └─ Cost: [metric.cost]{self._fmt_cost(stats['cost'])}[/metric.cost]  -  "
                 f"context {context_bar}{rate_str}"
             )
 
@@ -349,8 +380,7 @@ class DashboardUI:
             )
         else:
             time_section = (
-                f"[dashboard.header]Time[/dashboard.header]\n"
-                f"[dim]No timing data[/dim]"
+                f"[dashboard.header]Time[/dashboard.header]\n[dim]No timing data[/dim]"
             )
 
         status_text = (
@@ -412,8 +442,7 @@ class DashboardUI:
             )
         else:
             time_section = (
-                f"[dashboard.header]Time[/dashboard.header]\n"
-                f"[dim]No timing data[/dim]"
+                f"[dashboard.header]Time[/dashboard.header]\n[dim]No timing data[/dim]"
             )
 
         status_text = (
@@ -493,6 +522,7 @@ class DashboardUI:
                 f"[metric.label]{tool_name:<12}[/metric.label] "
                 f"[metric.value]{stat.total_calls:>4}[/metric.value] "
                 f"[{color}]{bar}[/{color}]"
+                f"{self._format_tool_token_suffix(stat)}"
             )
 
         tool_text = "\n".join(lines)
@@ -525,8 +555,12 @@ class DashboardUI:
         model_tool_usage: ModelToolUsage,
         max_tools: int = 15,
         model_tokens: Optional[int] = None,
+        model_token_details: Optional[Dict[str, int]] = None,
+        model_interactions: Optional[int] = None,
         model_cost: Optional[Decimal] = None,
         context_pct: Optional[float] = None,
+        context_size: Optional[int] = None,
+        context_window: Optional[int] = None,
         output_rate: Optional[float] = None,
     ) -> Panel:
         """Create a panel showing tool usage for a single model.
@@ -535,8 +569,12 @@ class DashboardUI:
             model_tool_usage: ModelToolUsage containing model name and tool stats
             max_tools: Maximum number of tools to display
             model_tokens: Optional token count for this model to display in header
+            model_token_details: Optional per-token-kind details for this model
+            model_interactions: Optional interaction/message count for this model
             model_cost: Optional cost for this model to display in header
             context_pct: Optional context usage percentage for this model
+            context_size: Optional recent context size for this model
+            context_window: Optional context window for this model
             output_rate: Optional output rate (tok/sec) for this model
 
         Returns:
@@ -559,22 +597,56 @@ class DashboardUI:
         lines = []
 
         if model_tokens is not None:
-            cost_str = f" [metric.cost]{self._fmt_cost(model_cost)}[/metric.cost]" if model_cost is not None else ""
-            
-            # Add context and output rate info
-            extra_info = []
+            details = model_token_details or {"total": model_tokens}
+            input_tokens = details.get("input", 0)
+            output_tokens = details.get("output", 0)
+            cache_read = details.get("cache_read", 0)
+            cache_write = details.get("cache_write", 0)
+            cache_total = cache_read + cache_write
+
+            lines.append(
+                f"[metric.label]Tokens:[/metric.label] "
+                f"[metric.value]{model_tokens:,}[/metric.value] [metric.tokens]total[/metric.tokens]"
+            )
+            if model_interactions is not None:
+                lines.append(
+                    f"  Interactions [metric.value]{model_interactions:,}[/metric.value]"
+                )
+            lines.append(
+                f"  Input [metric.value]{input_tokens:,}[/metric.value]  "
+                f"Output [metric.value]{output_tokens:,}[/metric.value]"
+            )
+            lines.append(
+                f"  Cache Read [metric.value]{cache_read:,}[/metric.value]  "
+                f"Write [metric.value]{cache_write:,}[/metric.value]"
+            )
+            lines.append(f"  Cache Total [metric.value]{cache_total:,}[/metric.value]")
+
+            if model_cost is not None or (output_rate is not None and output_rate > 0):
+                perf_parts = []
+                if model_cost is not None:
+                    perf_parts.append(
+                        f"Cost [metric.cost]{self._fmt_cost(model_cost)}[/metric.cost]"
+                    )
+                if output_rate is not None and output_rate > 0:
+                    perf_parts.append(
+                        f"Rate [metric.value]{output_rate:.1f}[/metric.value] tok/s"
+                    )
+                lines.append("  " + "  ".join(perf_parts))
+
             if context_pct is not None:
                 context_bar = self.create_compact_progress_bar(context_pct, 8)
-                extra_info.append(f"context {context_bar}")
-            if output_rate is not None and output_rate > 0:
-                extra_info.append(f"{output_rate:.1f} tok/s")
-            
-            extra_str = "  " + "  ".join(extra_info) if extra_info else ""
-            
+                if context_size is not None and context_window is not None:
+                    lines.append(
+                        f"  Ctx [metric.value]{context_size:,}[/metric.value]/"
+                        f"[metric.value]{context_window:,}[/metric.value] {context_bar}"
+                    )
+                else:
+                    lines.append(f"  Ctx {context_bar}")
+
             lines.append(
-                f"[metric.value]{model_tokens:,}[/metric.value] [metric.tokens]tokens[/metric.tokens]{cost_str}{extra_str}"
+                "[dashboard.border]────────────────────────[/dashboard.border]"
             )
-            lines.append("[dashboard.border]────────────────────────[/dashboard.border]")
 
         for stat in tool_stats:
             tool_name = stat.tool_name
@@ -589,6 +661,7 @@ class DashboardUI:
                 f"[metric.label]{tool_name:<12}[/metric.label] "
                 f"[metric.value]{stat.total_calls:>3}[/metric.value] "
                 f"[{color}]{bar}[/{color}]"
+                f"{self._format_tool_token_suffix(stat)}"
             )
 
         tool_text = "\n".join(lines)
@@ -633,20 +706,144 @@ class DashboardUI:
         per_model_output_rates = per_model_output_rates or {}
         per_model_context = per_model_context or {}
 
+        def _extract_token_details(tokens_value: Any) -> Dict[str, int]:
+            """Extract token kind totals from TokenUsage-like, dict, or numeric values."""
+
+            def _to_int(value: Any) -> int:
+                try:
+                    return int(value or 0)
+                except (TypeError, ValueError):
+                    return 0
+
+            if hasattr(tokens_value, "total"):
+                return {
+                    "input": _to_int(getattr(tokens_value, "input", 0)),
+                    "output": _to_int(getattr(tokens_value, "output", 0)),
+                    "cache_read": _to_int(getattr(tokens_value, "cache_read", 0)),
+                    "cache_write": _to_int(getattr(tokens_value, "cache_write", 0)),
+                    "total": _to_int(getattr(tokens_value, "total", 0)),
+                }
+
+            if isinstance(tokens_value, dict):
+                input_tokens = _to_int(tokens_value.get("input", 0))
+                output_tokens = _to_int(tokens_value.get("output", 0))
+                cache_read = _to_int(tokens_value.get("cache_read", 0))
+                cache_write = _to_int(tokens_value.get("cache_write", 0))
+                total = _to_int(
+                    tokens_value.get(
+                        "total", input_tokens + output_tokens + cache_read + cache_write
+                    )
+                )
+                return {
+                    "input": input_tokens,
+                    "output": output_tokens,
+                    "cache_read": cache_read,
+                    "cache_write": cache_write,
+                    "total": total,
+                }
+
+            total = _to_int(tokens_value)
+
+            return {
+                "input": 0,
+                "output": 0,
+                "cache_read": 0,
+                "cache_write": 0,
+                "total": total,
+            }
+
+        def _to_decimal(cost_value: Any) -> Decimal:
+            """Convert a cost value to Decimal safely."""
+            if isinstance(cost_value, Decimal):
+                return cost_value
+
+            try:
+                return Decimal(str(cost_value))
+            except (ArithmeticError, ValueError, TypeError):
+                return Decimal("0.0")
+
+        # Build bare-model fallbacks so SQLite tool rows (bare model IDs) can
+        # still match workflow model breakdown keys that are provider-prefixed.
+        model_breakdown_by_bare: Dict[str, Dict[str, Any]] = {}
+        for key, stats in model_breakdown.items():
+            if not isinstance(stats, dict):
+                continue
+
+            bare_model = key.split("/", 1)[-1]
+            bucket = model_breakdown_by_bare.setdefault(
+                bare_model,
+                {
+                    "token_details": {
+                        "input": 0,
+                        "output": 0,
+                        "cache_read": 0,
+                        "cache_write": 0,
+                        "total": 0,
+                    },
+                    "files": 0,
+                    "cost": Decimal("0.0"),
+                },
+            )
+            details = _extract_token_details(stats.get("tokens"))
+            for token_key, token_value in details.items():
+                bucket["token_details"][token_key] += token_value
+            bucket["files"] += int(stats.get("files", 0) or 0)
+            bucket["cost"] += _to_decimal(stats.get("cost", Decimal("0.0")))
+
+        per_model_context_by_bare: Dict[str, Dict[str, Any]] = {}
+        for key, context_info in per_model_context.items():
+            if isinstance(context_info, dict):
+                per_model_context_by_bare.setdefault(
+                    key.split("/", 1)[-1], context_info
+                )
+
+        per_model_output_rates_by_bare: Dict[str, float] = {}
+        for key, rate in per_model_output_rates.items():
+            per_model_output_rates_by_bare.setdefault(key.split("/", 1)[-1], rate)
+
         def get_model_info(model_name: str):
             """Return tokens, cost, context usage, and output rate for a model."""
-            if model_name in model_breakdown:
-                stats = model_breakdown[model_name]
-                tokens = stats.get("tokens", {}).total if hasattr(stats.get("tokens", {}), "total") else stats.get("tokens", 0)
-                cost = stats.get("cost")
+            bare_model = model_name.split("/", 1)[-1]
+
+            stats = model_breakdown.get(model_name)
+            if isinstance(stats, dict):
+                token_details = _extract_token_details(stats.get("tokens"))
+                tokens = token_details["total"]
+                interactions = int(stats.get("files", 0) or 0)
+                cost = _to_decimal(stats.get("cost", Decimal("0.0")))
             else:
-                tokens, cost = None, None
-            
-            context_info = per_model_context.get(model_name, {})
-            context_pct = context_info.get("usage_percentage")
-            output_rate = per_model_output_rates.get(model_name, 0.0)
-            
-            return tokens, cost, context_pct, output_rate
+                aggregate = model_breakdown_by_bare.get(bare_model)
+                if aggregate:
+                    token_details = aggregate["token_details"]
+                    tokens = token_details["total"]
+                    interactions = int(aggregate.get("files", 0) or 0)
+                    cost = aggregate["cost"]
+                else:
+                    tokens, token_details, interactions, cost = None, None, None, None
+
+            context_info = per_model_context.get(model_name)
+            if not isinstance(context_info, dict):
+                context_info = per_model_context_by_bare.get(bare_model, {})
+            context_pct = context_info.get("usage_percentage") if context_info else None
+            context_size = context_info.get("context_size") if context_info else None
+            context_window = (
+                context_info.get("context_window") if context_info else None
+            )
+
+            output_rate = per_model_output_rates.get(model_name)
+            if output_rate is None:
+                output_rate = per_model_output_rates_by_bare.get(bare_model, 0.0)
+
+            return (
+                tokens,
+                token_details,
+                interactions,
+                cost,
+                context_pct,
+                context_size,
+                context_window,
+                output_rate,
+            )
 
         left_models = []
         right_models = []
@@ -658,19 +855,55 @@ class DashboardUI:
 
         left_panels = []
         for model_usage in left_models:
-            model_tokens, model_cost, context_pct, output_rate = get_model_info(model_usage.model_name)
-            left_panels.append(self.create_model_tool_panel(
-                model_usage, model_tokens=model_tokens, model_cost=model_cost,
-                context_pct=context_pct, output_rate=output_rate
-            ))
+            (
+                model_tokens,
+                model_token_details,
+                model_interactions,
+                model_cost,
+                context_pct,
+                context_size,
+                context_window,
+                output_rate,
+            ) = get_model_info(model_usage.model_name)
+            left_panels.append(
+                self.create_model_tool_panel(
+                    model_usage,
+                    model_tokens=model_tokens,
+                    model_token_details=model_token_details,
+                    model_interactions=model_interactions,
+                    model_cost=model_cost,
+                    context_pct=context_pct,
+                    context_size=context_size,
+                    context_window=context_window,
+                    output_rate=output_rate,
+                )
+            )
 
         right_panels = []
         for model_usage in right_models:
-            model_tokens, model_cost, context_pct, output_rate = get_model_info(model_usage.model_name)
-            right_panels.append(self.create_model_tool_panel(
-                model_usage, model_tokens=model_tokens, model_cost=model_cost,
-                context_pct=context_pct, output_rate=output_rate
-            ))
+            (
+                model_tokens,
+                model_token_details,
+                model_interactions,
+                model_cost,
+                context_pct,
+                context_size,
+                context_window,
+                output_rate,
+            ) = get_model_info(model_usage.model_name)
+            right_panels.append(
+                self.create_model_tool_panel(
+                    model_usage,
+                    model_tokens=model_tokens,
+                    model_token_details=model_token_details,
+                    model_interactions=model_interactions,
+                    model_cost=model_cost,
+                    context_pct=context_pct,
+                    context_size=context_size,
+                    context_window=context_window,
+                    output_rate=output_rate,
+                )
+            )
 
         left_column = Layout()
         if left_panels:
@@ -722,7 +955,9 @@ class DashboardUI:
             # Create panels using workflow totals
             header = self.create_header(session, workflow)
             token_panel = self.create_workflow_token_panel(workflow, recent_file)
-            status_panel = self.create_workflow_status_panel(workflow, pricing_data, quota)
+            status_panel = self.create_workflow_status_panel(
+                workflow, pricing_data, quota
+            )
             model_panel = self.create_workflow_model_panel(
                 workflow, pricing_data, per_model_output_rates, per_model_context
             )
@@ -746,11 +981,27 @@ class DashboardUI:
         if use_grid:
             if workflow and workflow.has_sub_agents:
                 from collections import defaultdict
-                model_breakdown = defaultdict(lambda: {"tokens": 0, "cost": Decimal("0.0")})
+
+                model_breakdown = defaultdict(
+                    lambda: {
+                        "tokens": TokenUsage(),
+                        "files": 0,
+                        "cost": Decimal("0.0"),
+                    }
+                )
                 for sess in workflow.all_sessions:
                     sess_breakdown = sess.get_model_breakdown(pricing_data)
                     for model, stats in sess_breakdown.items():
-                        model_breakdown[model]["tokens"] += stats["tokens"].total
+                        model_tokens = stats["tokens"]
+                        model_breakdown[model]["tokens"].input += model_tokens.input
+                        model_breakdown[model]["tokens"].output += model_tokens.output
+                        model_breakdown[model][
+                            "tokens"
+                        ].cache_read += model_tokens.cache_read
+                        model_breakdown[model][
+                            "tokens"
+                        ].cache_write += model_tokens.cache_write
+                        model_breakdown[model]["files"] += stats.get("files", 0)
                         model_breakdown[model]["cost"] += stats["cost"]
                 model_breakdown = dict(model_breakdown)
             else:
@@ -782,14 +1033,18 @@ class DashboardUI:
             controls_panel = self.create_controls_panel(controls_hint)
             layout.split_column(
                 Layout(header, size=3),  # Compact header
-                Layout(name="metrics", size=12),  # Tokens + Status + Recent (single row)
+                Layout(
+                    name="metrics", size=12
+                ),  # Tokens + Status + Recent (single row)
                 Layout(name="models_tools", minimum_size=4),  # Model + Tool breakdown
                 Layout(controls_panel, size=3),  # Persistent keybind visibility
             )
         else:
             layout.split_column(
                 Layout(header, size=3),  # Compact header
-                Layout(name="metrics", size=12),  # Tokens + Status + Recent (single row)
+                Layout(
+                    name="metrics", size=12
+                ),  # Tokens + Status + Recent (single row)
                 Layout(name="models_tools", minimum_size=4),  # Model + Tool breakdown
             )
 
@@ -943,13 +1198,18 @@ class DashboardUI:
 
         # Aggregate model stats across all sessions
         model_data: Dict[str, Dict[str, Any]] = defaultdict(
-            lambda: {"tokens": 0, "cost": Decimal("0.0")}
+            lambda: {"tokens": TokenUsage(), "files": 0, "cost": Decimal("0.0")}
         )
 
         for session in workflow.all_sessions:
             model_breakdown = session.get_model_breakdown(pricing_data)
             for model, stats in model_breakdown.items():
-                model_data[model]["tokens"] += stats["tokens"].total
+                model_tokens = stats["tokens"]
+                model_data[model]["tokens"].input += model_tokens.input
+                model_data[model]["tokens"].output += model_tokens.output
+                model_data[model]["tokens"].cache_read += model_tokens.cache_read
+                model_data[model]["tokens"].cache_write += model_tokens.cache_write
+                model_data[model]["files"] += stats.get("files", 0)
                 model_data[model]["cost"] += stats["cost"]
 
         if not model_data:
@@ -964,21 +1224,41 @@ class DashboardUI:
             model_data.items(), key=lambda x: x[1]["cost"], reverse=True
         ):
             model_name = model[:35] + "..." if len(model) > 38 else model
-            
+            bare_model = model.split("/", 1)[-1]
+            token_usage = stats["tokens"]
+
             # Get context usage for this model
-            context_info = per_model_context.get(model, {})
+            context_info = per_model_context.get(model) or per_model_context.get(
+                bare_model, {}
+            )
             context_pct = context_info.get("usage_percentage", 0.0)
             context_bar = self.create_compact_progress_bar(context_pct, 8)
-            
+            context_size = context_info.get("context_size")
+            context_window = context_info.get("context_window")
+            if context_size is not None and context_window is not None:
+                context_str = (
+                    f"context [metric.value]{context_size:,}[/metric.value]/"
+                    f"[metric.value]{context_window:,}[/metric.value] {context_bar}"
+                )
+            else:
+                context_str = f"context {context_bar}"
+
             # Get output rate for this model
-            output_rate = per_model_output_rates.get(model, 0.0)
+            output_rate = per_model_output_rates.get(
+                model, per_model_output_rates.get(bare_model, 0.0)
+            )
             rate_str = f" - {output_rate:.1f} tok/s" if output_rate > 0 else ""
-            
+
             model_lines.append(
-                f"[metric.label]{model_name}[/metric.label]  -  "
-                f"[metric.value]{stats['tokens']:,}[/metric.value] [metric.tokens]tok[/metric.tokens]  "
-                f"[metric.cost]{self._fmt_cost(stats['cost'])}[/metric.cost]  -  "
-                f"context {context_bar}{rate_str}"
+                f"[metric.label]{model_name}[/metric.label]\n"
+                f"  └─ Tokens: [metric.value]{token_usage.total:,}[/metric.value] tok "
+                f"([metric.label]In:[/metric.label] [metric.value]{token_usage.input:,}[/metric.value] | "
+                f"[metric.label]Out:[/metric.label] [metric.value]{token_usage.output:,}[/metric.value] | "
+                f"[metric.label]CW:[/metric.label] [metric.value]{token_usage.cache_write:,}[/metric.value] | "
+                f"[metric.label]CR:[/metric.label] [metric.value]{token_usage.cache_read:,}[/metric.value])\n"
+                f"  └─ Interactions: [metric.value]{stats['files']:,}[/metric.value]  -  "
+                f"Cost: [metric.cost]{self._fmt_cost(stats['cost'])}[/metric.cost]  -  "
+                f"{context_str}{rate_str}"
             )
 
         model_text = "\n".join(model_lines)

--- a/ocmonitor/utils/sqlite_utils.py
+++ b/ocmonitor/utils/sqlite_utils.py
@@ -96,10 +96,10 @@ class SQLiteProcessor:
         cache_data = tokens_data.get("cache", {})
 
         return TokenUsage(
-            input=max(0, tokens_data.get('input', 0)),
-            output=max(0, tokens_data.get('output', 0)),
-            cache_write=max(0, cache_data.get('write', 0)),
-            cache_read=max(0, cache_data.get('read', 0))
+            input=max(0, tokens_data.get("input", 0)),
+            output=max(0, tokens_data.get("output", 0)),
+            cache_write=max(0, cache_data.get("write", 0)),
+            cache_read=max(0, cache_data.get("read", 0)),
         )
 
     @staticmethod
@@ -673,39 +673,37 @@ class SQLiteProcessor:
             return stats
         finally:
             conn.close()
-    
+
     @classmethod
     def load_tool_usage_for_sessions(
-        cls,
-        session_ids: List[str],
-        db_path: Optional[Path] = None
+        cls, session_ids: List[str], db_path: Optional[Path] = None
     ) -> List[ToolUsageStats]:
         """Load tool usage statistics for the given sessions.
-        
+
         Queries the `part` table for tool entries with terminal statuses
         (completed or error) and aggregates counts by tool name.
-        
+
         Args:
             session_ids: List of session IDs to aggregate tool usage for
             db_path: Path to database (uses default if not provided)
-            
+
         Returns:
             List of ToolUsageStats sorted by total_calls descending
         """
         if not session_ids:
             return []
-        
+
         if db_path is None:
             db_path = cls.find_database_path()
-        
+
         if not db_path or not db_path.exists():
             return []
-        
+
         conn = cls._get_connection(db_path)
         try:
             # Build placeholders for IN clause
-            placeholders = ','.join('?' * len(session_ids))
-            
+            placeholders = ",".join("?" * len(session_ids))
+
             # Query tool parts with terminal statuses
             # Use json_valid to protect against malformed JSON
             # Use json_extract to access nested fields in the data column
@@ -722,73 +720,144 @@ class SQLiteProcessor:
                   AND json_extract(data, '$.state.status') IN ('completed', 'error')
                 GROUP BY tool_name, status
             """
-            
+
             cursor = conn.execute(query, session_ids)
-            
+
             # Aggregate by tool name
             tool_data: Dict[str, Dict[str, int]] = {}
             for row in cursor:
-                tool_name = row['tool_name']
-                status = row['status']
-                count = row['count']
-                
+                tool_name = row["tool_name"]
+                status = row["status"]
+                count = row["count"]
+
                 if tool_name not in tool_data:
-                    tool_data[tool_name] = {'success': 0, 'failure': 0}
-                
-                if status == 'completed':
-                    tool_data[tool_name]['success'] += count
-                elif status == 'error':
-                    tool_data[tool_name]['failure'] += count
-            
+                    tool_data[tool_name] = {
+                        "success": 0,
+                        "failure": 0,
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "cache_read_tokens": 0,
+                        "cache_write_tokens": 0,
+                    }
+
+                if status == "completed":
+                    tool_data[tool_name]["success"] += count
+                elif status == "error":
+                    tool_data[tool_name]["failure"] += count
+
+            # Attribute message-level tokens to tools. OpenCode records tokens on
+            # assistant messages, while tool calls are separate part rows. For a
+            # message with multiple terminal tool calls, split the message tokens
+            # evenly across those calls to avoid double-counting.
+            token_query = f"""
+                WITH terminal_tools AS (
+                    SELECT
+                        p.session_id,
+                        p.message_id,
+                        json_extract(p.data, '$.tool') as tool_name,
+                        m.data as message_data
+                    FROM part p
+                    JOIN message m ON p.message_id = m.id
+                    WHERE p.session_id IN ({placeholders})
+                      AND json_valid(p.data) = 1
+                      AND json_valid(m.data) = 1
+                      AND json_extract(p.data, '$.type') = 'tool'
+                      AND json_extract(p.data, '$.tool') IS NOT NULL
+                      AND json_extract(p.data, '$.state.status') IN ('completed', 'error')
+                ),
+                message_tool_counts AS (
+                    SELECT session_id, message_id, COUNT(*) as tool_count
+                    FROM terminal_tools
+                    GROUP BY session_id, message_id
+                )
+                SELECT
+                    t.tool_name,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.input'), 0) * 1.0 / mtc.tool_count) as input_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.output'), 0) * 1.0 / mtc.tool_count) as output_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.cache.read'), 0) * 1.0 / mtc.tool_count) as cache_read_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.cache.write'), 0) * 1.0 / mtc.tool_count) as cache_write_tokens
+                FROM terminal_tools t
+                JOIN message_tool_counts mtc
+                  ON t.session_id = mtc.session_id
+                 AND t.message_id = mtc.message_id
+                GROUP BY t.tool_name
+            """
+
+            try:
+                token_cursor = conn.execute(token_query, session_ids)
+                for row in token_cursor:
+                    tool_name = row["tool_name"]
+                    if tool_name not in tool_data:
+                        continue
+                    tool_data[tool_name]["input_tokens"] = round(
+                        row["input_tokens"] or 0
+                    )
+                    tool_data[tool_name]["output_tokens"] = round(
+                        row["output_tokens"] or 0
+                    )
+                    tool_data[tool_name]["cache_read_tokens"] = round(
+                        row["cache_read_tokens"] or 0
+                    )
+                    tool_data[tool_name]["cache_write_tokens"] = round(
+                        row["cache_write_tokens"] or 0
+                    )
+            except sqlite3.OperationalError:
+                # Legacy/minimal DBs may not have a message table; keep counts.
+                pass
+
             # Build ToolUsageStats list
             stats = []
             for tool_name, counts in tool_data.items():
-                total = counts['success'] + counts['failure']
-                stats.append(ToolUsageStats(
-                    tool_name=tool_name,
-                    total_calls=total,
-                    success_count=counts['success'],
-                    failure_count=counts['failure']
-                ))
-            
+                total = counts["success"] + counts["failure"]
+                stats.append(
+                    ToolUsageStats(
+                        tool_name=tool_name,
+                        total_calls=total,
+                        success_count=counts["success"],
+                        failure_count=counts["failure"],
+                        input_tokens=counts["input_tokens"],
+                        output_tokens=counts["output_tokens"],
+                        cache_read_tokens=counts["cache_read_tokens"],
+                        cache_write_tokens=counts["cache_write_tokens"],
+                    )
+                )
+
             # Sort by total_calls descending
             stats.sort(key=lambda s: s.total_calls, reverse=True)
-            
+
             return stats
         finally:
             conn.close()
 
     @classmethod
     def load_tool_usage_by_model_for_sessions(
-        cls,
-        session_ids: List[str],
-        db_path: Optional[Path] = None
+        cls, session_ids: List[str], db_path: Optional[Path] = None
     ) -> List[ModelToolUsage]:
         """Load tool usage statistics grouped by model for the given sessions.
-        
+
         Queries the `part` table joined with `message` to get model information
         for each tool call. Aggregates counts by model and tool name.
-        
+
         Args:
             session_ids: List of session IDs to aggregate tool usage for
             db_path: Path to database (uses default if not provided)
-            
+
         Returns:
             List of ModelToolUsage sorted by total_calls descending
         """
         if not session_ids:
             return []
-        
+
         if db_path is None:
             db_path = cls.find_database_path()
-        
+
         if not db_path or not db_path.exists():
             return []
-        
+
         conn = cls._get_connection(db_path)
         try:
-            placeholders = ','.join('?' * len(session_ids))
-            
+            placeholders = ",".join("?" * len(session_ids))
+
             query = f"""
                 SELECT 
                     COALESCE(
@@ -809,43 +878,118 @@ class SQLiteProcessor:
                   AND json_extract(p.data, '$.state.status') IN ('completed', 'error')
                 GROUP BY model_id, tool_name, status
             """
-            
+
             cursor = conn.execute(query, session_ids)
-            
+
             model_data: Dict[str, Dict[str, Dict[str, int]]] = {}
             for row in cursor:
-                model_id = row['model_id']
-                tool_name = row['tool_name']
-                status = row['status']
-                count = row['count']
-                
+                model_id = row["model_id"]
+                tool_name = row["tool_name"]
+                status = row["status"]
+                count = row["count"]
+
                 if model_id not in model_data:
                     model_data[model_id] = {}
                 if tool_name not in model_data[model_id]:
-                    model_data[model_id][tool_name] = {'success': 0, 'failure': 0}
-                
-                if status == 'completed':
-                    model_data[model_id][tool_name]['success'] += count
-                elif status == 'error':
-                    model_data[model_id][tool_name]['failure'] += count
-            
+                    model_data[model_id][tool_name] = {
+                        "success": 0,
+                        "failure": 0,
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "cache_read_tokens": 0,
+                        "cache_write_tokens": 0,
+                    }
+
+                if status == "completed":
+                    model_data[model_id][tool_name]["success"] += count
+                elif status == "error":
+                    model_data[model_id][tool_name]["failure"] += count
+
+            # Attribute message-level tokens to each model/tool pair. Tokens are
+            # stored on assistant messages, not individual tool rows. Split a
+            # message's tokens evenly across its terminal tool calls to avoid
+            # over-counting when multiple tools share one message.
+            token_query = f"""
+                WITH terminal_tools AS (
+                    SELECT
+                        p.session_id,
+                        p.message_id,
+                        COALESCE(
+                            json_extract(m.data, '$.modelID'),
+                            json_extract(m.data, '$.model.modelID'),
+                            'unknown'
+                        ) as model_id,
+                        json_extract(p.data, '$.tool') as tool_name,
+                        m.data as message_data
+                    FROM part p
+                    JOIN message m ON p.message_id = m.id
+                    WHERE p.session_id IN ({placeholders})
+                      AND json_valid(p.data) = 1
+                      AND json_valid(m.data) = 1
+                      AND json_extract(p.data, '$.type') = 'tool'
+                      AND json_extract(p.data, '$.tool') IS NOT NULL
+                      AND json_extract(p.data, '$.state.status') IN ('completed', 'error')
+                ),
+                message_tool_counts AS (
+                    SELECT session_id, message_id, COUNT(*) as tool_count
+                    FROM terminal_tools
+                    GROUP BY session_id, message_id
+                )
+                SELECT
+                    t.model_id,
+                    t.tool_name,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.input'), 0) * 1.0 / mtc.tool_count) as input_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.output'), 0) * 1.0 / mtc.tool_count) as output_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.cache.read'), 0) * 1.0 / mtc.tool_count) as cache_read_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.cache.write'), 0) * 1.0 / mtc.tool_count) as cache_write_tokens
+                FROM terminal_tools t
+                JOIN message_tool_counts mtc
+                  ON t.session_id = mtc.session_id
+                 AND t.message_id = mtc.message_id
+                GROUP BY t.model_id, t.tool_name
+            """
+
+            token_cursor = conn.execute(token_query, session_ids)
+            for row in token_cursor:
+                model_id = row["model_id"]
+                tool_name = row["tool_name"]
+                if model_id not in model_data or tool_name not in model_data[model_id]:
+                    continue
+                model_data[model_id][tool_name]["input_tokens"] = round(
+                    row["input_tokens"] or 0
+                )
+                model_data[model_id][tool_name]["output_tokens"] = round(
+                    row["output_tokens"] or 0
+                )
+                model_data[model_id][tool_name]["cache_read_tokens"] = round(
+                    row["cache_read_tokens"] or 0
+                )
+                model_data[model_id][tool_name]["cache_write_tokens"] = round(
+                    row["cache_write_tokens"] or 0
+                )
+
             result = []
             for model_name, tools in model_data.items():
                 tool_stats = []
                 for tool_name, counts in tools.items():
-                    total = counts['success'] + counts['failure']
-                    tool_stats.append(ToolUsageStats(
-                        tool_name=tool_name,
-                        total_calls=total,
-                        success_count=counts['success'],
-                        failure_count=counts['failure']
-                    ))
+                    total = counts["success"] + counts["failure"]
+                    tool_stats.append(
+                        ToolUsageStats(
+                            tool_name=tool_name,
+                            total_calls=total,
+                            success_count=counts["success"],
+                            failure_count=counts["failure"],
+                            input_tokens=counts["input_tokens"],
+                            output_tokens=counts["output_tokens"],
+                            cache_read_tokens=counts["cache_read_tokens"],
+                            cache_write_tokens=counts["cache_write_tokens"],
+                        )
+                    )
                 tool_stats.sort(key=lambda s: s.total_calls, reverse=True)
-                result.append(ModelToolUsage(
-                    model_name=model_name,
-                    tool_stats=tool_stats
-                ))
-            
+                result.append(
+                    ModelToolUsage(model_name=model_name, tool_stats=tool_stats)
+                )
+
             result.sort(key=lambda m: m.total_calls, reverse=True)
 
             return result
@@ -893,13 +1037,18 @@ class SQLiteProcessor:
                 """,
                 (f"%{query.lower()}%",),
             )
-            return [row["model_name"] for row in cursor if row["model_name"] != "unknown"]
+            return [
+                row["model_name"] for row in cursor if row["model_name"] != "unknown"
+            ]
         finally:
             conn.close()
 
     @classmethod
     def get_model_detail_stats(
-        cls, model_name: str, pricing_data: Dict[str, Any], db_path: Optional[Path] = None
+        cls,
+        model_name: str,
+        pricing_data: Dict[str, Any],
+        db_path: Optional[Path] = None,
     ) -> Optional[ModelDetailStats]:
         """Get detailed statistics for a single model.
 
@@ -973,28 +1122,40 @@ class SQLiteProcessor:
             )
 
             # Calculate cost using pricing data
-            total_cost = Decimal('0.0')
+            total_cost = Decimal("0.0")
             model_pricing = FileProcessor.lookup_pricing(
                 pricing_data,
                 model_id=model_name,
                 provider_id=None,
             )
             if model_pricing:
-                price_input = getattr(model_pricing, 'input', 0) or 0
-                price_output = getattr(model_pricing, 'output', 0) or 0
-                price_cache_read = getattr(model_pricing, 'cacheRead', 0) or 0
-                price_cache_write = getattr(model_pricing, 'cacheWrite', 0) or 0
+                price_input = getattr(model_pricing, "input", 0) or 0
+                price_output = getattr(model_pricing, "output", 0) or 0
+                price_cache_read = getattr(model_pricing, "cacheRead", 0) or 0
+                price_cache_write = getattr(model_pricing, "cacheWrite", 0) or 0
                 total_cost = (
-                    Decimal(str(tokens.input)) * Decimal(str(price_input)) / Decimal('1000000')
-                    + Decimal(str(tokens.output)) * Decimal(str(price_output)) / Decimal('1000000')
-                    + Decimal(str(tokens.cache_read)) * Decimal(str(price_cache_read)) / Decimal('1000000')
-                    + Decimal(str(tokens.cache_write)) * Decimal(str(price_cache_write)) / Decimal('1000000')
+                    Decimal(str(tokens.input))
+                    * Decimal(str(price_input))
+                    / Decimal("1000000")
+                    + Decimal(str(tokens.output))
+                    * Decimal(str(price_output))
+                    / Decimal("1000000")
+                    + Decimal(str(tokens.cache_read))
+                    * Decimal(str(price_cache_read))
+                    / Decimal("1000000")
+                    + Decimal(str(tokens.cache_write))
+                    * Decimal(str(price_cache_write))
+                    / Decimal("1000000")
                 )
 
             total_sessions = row["total_sessions"]
             total_days = row["total_days"]
-            avg_cost_per_day = total_cost / total_days if total_days > 0 else Decimal('0.0')
-            avg_cost_per_session = total_cost / total_sessions if total_sessions > 0 else Decimal('0.0')
+            avg_cost_per_day = (
+                total_cost / total_days if total_days > 0 else Decimal("0.0")
+            )
+            avg_cost_per_session = (
+                total_cost / total_sessions if total_sessions > 0 else Decimal("0.0")
+            )
 
             # Query 2: Per-interaction output rates for p50 calculation
             rate_cursor = conn.execute(
@@ -1062,12 +1223,14 @@ class SQLiteProcessor:
 
             tool_stats = []
             for tool_row in tool_cursor:
-                tool_stats.append(ToolUsageStats(
-                    tool_name=tool_row["tool_name"],
-                    total_calls=tool_row["total_calls"],
-                    success_count=tool_row["success"],
-                    failure_count=tool_row["failed"],
-                ))
+                tool_stats.append(
+                    ToolUsageStats(
+                        tool_name=tool_row["tool_name"],
+                        total_calls=tool_row["total_calls"],
+                        success_count=tool_row["success"],
+                        failure_count=tool_row["failed"],
+                    )
+                )
 
             tool_summary = ToolUsageSummary(tool_stats=tool_stats)
 

--- a/tests/unit/test_sqlite_tool_usage.py
+++ b/tests/unit/test_sqlite_tool_usage.py
@@ -21,7 +21,7 @@ class TestLoadToolUsageForSessions:
         db_path = tmp_path / "test_opencode.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
+
         # Create tables
         conn.execute("""
             CREATE TABLE session (
@@ -33,7 +33,7 @@ class TestLoadToolUsageForSessions:
                 time_updated INTEGER NOT NULL
             )
         """)
-        
+
         conn.execute("""
             CREATE TABLE part (
                 id TEXT PRIMARY KEY,
@@ -44,90 +44,77 @@ class TestLoadToolUsageForSessions:
                 data TEXT NOT NULL
             )
         """)
-        
+
         # Insert test sessions
         conn.execute(
             "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_test1", "proj_1", None, "Test Session 1", 1000, 2000)
+            ("ses_test1", "proj_1", None, "Test Session 1", 1000, 2000),
         )
         conn.execute(
             "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_test2", "proj_1", None, "Test Session 2", 3000, 4000)
+            ("ses_test2", "proj_1", None, "Test Session 2", 3000, 4000),
         )
-        
+
         # Insert tool parts for session 1
         # bash: 3 completed, 1 error
         for i, status in enumerate(["completed", "completed", "completed", "error"]):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "bash",
-                "state": {"status": status}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "bash", "state": {"status": status}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_bash_{i}", "msg_1", "ses_test1", 1000 + i, 1000 + i, data)
+                (f"prt_bash_{i}", "msg_1", "ses_test1", 1000 + i, 1000 + i, data),
             )
-        
+
         # read: 2 completed
         for i in range(2):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "read",
-                "state": {"status": "completed"}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "read", "state": {"status": "completed"}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_read_{i}", "msg_1", "ses_test1", 2000 + i, 2000 + i, data)
+                (f"prt_read_{i}", "msg_1", "ses_test1", 2000 + i, 2000 + i, data),
             )
-        
+
         # edit: 1 completed, 2 error
         for i, status in enumerate(["completed", "error", "error"]):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "edit",
-                "state": {"status": status}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "edit", "state": {"status": status}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_edit_{i}", "msg_1", "ses_test1", 3000 + i, 3000 + i, data)
+                (f"prt_edit_{i}", "msg_1", "ses_test1", 3000 + i, 3000 + i, data),
             )
-        
+
         # Insert tool parts for session 2
         # bash: 1 completed
-        data = json.dumps({
-            "type": "tool",
-            "tool": "bash",
-            "state": {"status": "completed"}
-        })
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "completed"}}
+        )
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_bash_s2", "msg_2", "ses_test2", 3000, 3000, data)
+            ("prt_bash_s2", "msg_2", "ses_test2", 3000, 3000, data),
         )
-        
+
         # Insert non-tool parts (should be ignored)
-        data = json.dumps({
-            "type": "text",
-            "text": "Some text"
-        })
+        data = json.dumps({"type": "text", "text": "Some text"})
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_text", "msg_1", "ses_test1", 4000, 4000, data)
+            ("prt_text", "msg_1", "ses_test1", 4000, 4000, data),
         )
-        
+
         # Insert running tool (should be ignored)
-        data = json.dumps({
-            "type": "tool",
-            "tool": "bash",
-            "state": {"status": "running"}
-        })
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "running"}}
+        )
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_running", "msg_1", "ses_test1", 5000, 5000, data)
+            ("prt_running", "msg_1", "ses_test1", 5000, 5000, data),
         )
-        
+
         conn.commit()
         conn.close()
-        
+
         return db_path
 
     def test_load_tool_usage_aggregates_correctly(self, temp_db: Path):
@@ -135,23 +122,23 @@ class TestLoadToolUsageForSessions:
         stats = SQLiteProcessor.load_tool_usage_for_sessions(
             ["ses_test1", "ses_test2"], temp_db
         )
-        
+
         assert len(stats) == 3
-        
+
         # bash should be first (most calls: 4 completed from ses_test1 + 1 completed from ses_test2 + 1 error = 5 total)
         assert stats[0].tool_name == "bash"
         assert stats[0].total_calls == 5  # 4 completed + 1 error (running is excluded)
         assert stats[0].success_count == 4  # 3 from ses_test1 + 1 from ses_test2
         assert stats[0].failure_count == 1
         assert stats[0].success_rate == 80.0
-        
+
         # edit: 1 completed + 2 error = 3 total
         edit_stat = next(s for s in stats if s.tool_name == "edit")
         assert edit_stat.total_calls == 3
         assert edit_stat.success_count == 1
         assert edit_stat.failure_count == 2
         assert edit_stat.success_rate == pytest.approx(33.33, rel=0.01)
-        
+
         # read: 2 completed
         read_stat = next(s for s in stats if s.tool_name == "read")
         assert read_stat.total_calls == 2
@@ -161,10 +148,8 @@ class TestLoadToolUsageForSessions:
 
     def test_load_tool_usage_excludes_running_status(self, temp_db: Path):
         """Test that running status is excluded from stats."""
-        stats = SQLiteProcessor.load_tool_usage_for_sessions(
-            ["ses_test1"], temp_db
-        )
-        
+        stats = SQLiteProcessor.load_tool_usage_for_sessions(["ses_test1"], temp_db)
+
         # The running bash command should be excluded
         # ses_test1 has: 3 bash completed, 1 bash error, 1 bash running
         # So bash should have 4 total (3 completed + 1 error), not 5
@@ -185,7 +170,7 @@ class TestLoadToolUsageForSessions:
 
     def test_load_tool_usage_missing_db_path(self, tmp_path: Path):
         """Test that missing database path returns empty list."""
-        with patch.object(SQLiteProcessor, 'find_database_path', return_value=None):
+        with patch.object(SQLiteProcessor, "find_database_path", return_value=None):
             stats = SQLiteProcessor.load_tool_usage_for_sessions(["ses_test"])
             assert stats == []
 
@@ -194,7 +179,7 @@ class TestLoadToolUsageForSessions:
         stats = SQLiteProcessor.load_tool_usage_for_sessions(
             ["ses_test1", "ses_test2"], temp_db
         )
-        
+
         # Verify sorted by total_calls descending
         for i in range(len(stats) - 1):
             assert stats[i].total_calls >= stats[i + 1].total_calls
@@ -204,7 +189,7 @@ class TestLoadToolUsageForSessions:
         db_path = tmp_path / "test_malformed.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
+
         # Create tables
         conn.execute("""
             CREATE TABLE session (
@@ -216,7 +201,7 @@ class TestLoadToolUsageForSessions:
                 time_updated INTEGER NOT NULL
             )
         """)
-        
+
         conn.execute("""
             CREATE TABLE part (
                 id TEXT PRIMARY KEY,
@@ -227,44 +212,47 @@ class TestLoadToolUsageForSessions:
                 data TEXT NOT NULL
             )
         """)
-        
+
         # Insert test session
         conn.execute(
             "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_malformed", "proj_1", None, "Malformed Test", 1000, 2000)
+            ("ses_malformed", "proj_1", None, "Malformed Test", 1000, 2000),
         )
-        
+
         # Insert valid tool
-        data = json.dumps({
-            "type": "tool",
-            "tool": "bash",
-            "state": {"status": "completed"}
-        })
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "completed"}}
+        )
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_valid", "msg_1", "ses_malformed", 1000, 1000, data)
+            ("prt_valid", "msg_1", "ses_malformed", 1000, 1000, data),
         )
-        
+
         # Insert malformed JSON (should be ignored without error)
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_malformed", "msg_1", "ses_malformed", 2000, 2000, "{not valid json}")
+            ("prt_malformed", "msg_1", "ses_malformed", 2000, 2000, "{not valid json}"),
         )
-        
+
         # Insert malformed JSON that looks like tool (should be ignored)
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_malformed2", "msg_1", "ses_malformed", 3000, 3000, '{"type": "tool", "tool": "edit"')
+            (
+                "prt_malformed2",
+                "msg_1",
+                "ses_malformed",
+                3000,
+                3000,
+                '{"type": "tool", "tool": "edit"',
+            ),
         )
-        
+
         conn.commit()
         conn.close()
-        
+
         # Should not raise and should only count valid tool
-        stats = SQLiteProcessor.load_tool_usage_for_sessions(
-            ["ses_malformed"], db_path
-        )
-        
+        stats = SQLiteProcessor.load_tool_usage_for_sessions(["ses_malformed"], db_path)
+
         assert len(stats) == 1
         assert stats[0].tool_name == "bash"
         assert stats[0].total_calls == 1
@@ -274,7 +262,7 @@ class TestLoadToolUsageForSessions:
         db_path = tmp_path / "test_null_tool.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
+
         # Create tables
         conn.execute("""
             CREATE TABLE session (
@@ -286,7 +274,7 @@ class TestLoadToolUsageForSessions:
                 time_updated INTEGER NOT NULL
             )
         """)
-        
+
         conn.execute("""
             CREATE TABLE part (
                 id TEXT PRIMARY KEY,
@@ -297,42 +285,35 @@ class TestLoadToolUsageForSessions:
                 data TEXT NOT NULL
             )
         """)
-        
+
         # Insert test session
         conn.execute(
             "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_null", "proj_1", None, "Null Tool Test", 1000, 2000)
+            ("ses_null", "proj_1", None, "Null Tool Test", 1000, 2000),
         )
-        
+
         # Insert valid tool
-        data = json.dumps({
-            "type": "tool",
-            "tool": "read",
-            "state": {"status": "completed"}
-        })
+        data = json.dumps(
+            {"type": "tool", "tool": "read", "state": {"status": "completed"}}
+        )
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_valid", "msg_1", "ses_null", 1000, 1000, data)
+            ("prt_valid", "msg_1", "ses_null", 1000, 1000, data),
         )
-        
+
         # Insert tool with null tool name (missing 'tool' field)
-        data = json.dumps({
-            "type": "tool",
-            "state": {"status": "completed"}
-        })
+        data = json.dumps({"type": "tool", "state": {"status": "completed"}})
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_null_tool", "msg_1", "ses_null", 2000, 2000, data)
+            ("prt_null_tool", "msg_1", "ses_null", 2000, 2000, data),
         )
-        
+
         conn.commit()
         conn.close()
-        
+
         # Should not raise and should only count valid tool
-        stats = SQLiteProcessor.load_tool_usage_for_sessions(
-            ["ses_null"], db_path
-        )
-        
+        stats = SQLiteProcessor.load_tool_usage_for_sessions(["ses_null"], db_path)
+
         assert len(stats) == 1
         assert stats[0].tool_name == "read"
 
@@ -343,10 +324,7 @@ class TestToolUsageStatsModel:
     def test_success_rate_calculation(self):
         """Test success rate is calculated correctly."""
         stats = ToolUsageStats(
-            tool_name="test",
-            total_calls=10,
-            success_count=8,
-            failure_count=2
+            tool_name="test", total_calls=10, success_count=8, failure_count=2
         )
         assert stats.success_rate == 80.0
 
@@ -372,7 +350,7 @@ class TestLoadToolUsageByModelForSessions:
         db_path = tmp_path / "test_opencode.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
+
         conn.execute("""
             CREATE TABLE session (
                 id TEXT PRIMARY KEY,
@@ -383,7 +361,7 @@ class TestLoadToolUsageByModelForSessions:
                 time_updated INTEGER NOT NULL
             )
         """)
-        
+
         conn.execute("""
             CREATE TABLE message (
                 id TEXT PRIMARY KEY,
@@ -393,7 +371,7 @@ class TestLoadToolUsageByModelForSessions:
                 data TEXT NOT NULL
             )
         """)
-        
+
         conn.execute("""
             CREATE TABLE part (
                 id TEXT PRIMARY KEY,
@@ -404,117 +382,178 @@ class TestLoadToolUsageByModelForSessions:
                 data TEXT NOT NULL
             )
         """)
-        
+
         conn.execute(
             "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_model_test", "proj_1", None, "Model Test", 1000, 2000)
+            ("ses_model_test", "proj_1", None, "Model Test", 1000, 2000),
         )
-        
+
         conn.execute(
             "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
-            ("msg_1", "ses_model_test", 1000, 1000, json.dumps({"role": "assistant", "modelID": "claude-3-5-sonnet-20241022"}))
+            (
+                "msg_1",
+                "ses_model_test",
+                1000,
+                1000,
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "modelID": "claude-3-5-sonnet-20241022",
+                        "tokens": {
+                            "input": 500,
+                            "output": 250,
+                            "cache": {"read": 1000, "write": 50},
+                        },
+                    }
+                ),
+            ),
         )
-        
+
         conn.execute(
             "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
-            ("msg_2", "ses_model_test", 2000, 2000, json.dumps({"role": "assistant", "modelID": "claude-3-5-haiku-20240307"}))
+            (
+                "msg_2",
+                "ses_model_test",
+                2000,
+                2000,
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "modelID": "claude-3-5-haiku-20240307",
+                        "tokens": {
+                            "input": 90,
+                            "output": 30,
+                            "cache": {"read": 300, "write": 60},
+                        },
+                    }
+                ),
+            ),
         )
-        
+
         for i, status in enumerate(["completed", "completed", "error"]):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "bash",
-                "state": {"status": status}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "bash", "state": {"status": status}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_sonnet_bash_{i}", "msg_1", "ses_model_test", 1000 + i, 1000 + i, data)
+                (
+                    f"prt_sonnet_bash_{i}",
+                    "msg_1",
+                    "ses_model_test",
+                    1000 + i,
+                    1000 + i,
+                    data,
+                ),
             )
-        
+
         for i in range(2):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "read",
-                "state": {"status": "completed"}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "read", "state": {"status": "completed"}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_sonnet_read_{i}", "msg_1", "ses_model_test", 2000 + i, 2000 + i, data)
+                (
+                    f"prt_sonnet_read_{i}",
+                    "msg_1",
+                    "ses_model_test",
+                    2000 + i,
+                    2000 + i,
+                    data,
+                ),
             )
-        
+
         for i, status in enumerate(["completed", "error", "error"]):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "edit",
-                "state": {"status": status}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "edit", "state": {"status": status}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_haiku_edit_{i}", "msg_2", "ses_model_test", 3000 + i, 3000 + i, data)
+                (
+                    f"prt_haiku_edit_{i}",
+                    "msg_2",
+                    "ses_model_test",
+                    3000 + i,
+                    3000 + i,
+                    data,
+                ),
             )
-        
-        data = json.dumps({
-            "type": "tool",
-            "tool": "bash",
-            "state": {"status": "running"}
-        })
+
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "running"}}
+        )
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_haiku_running", "msg_2", "ses_model_test", 4000, 4000, data)
+            ("prt_haiku_running", "msg_2", "ses_model_test", 4000, 4000, data),
         )
-        
+
         conn.commit()
         conn.close()
-        
+
         return db_path
 
     def test_groups_tools_by_model(self, temp_db_with_messages: Path):
         """Test that tools are grouped correctly by model."""
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
         from ocmonitor.models.tool_usage import ModelToolUsage
-        
+
         stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
             ["ses_model_test"], temp_db_with_messages
         )
-        
+
         assert len(stats) == 2
-        
+
         stats_by_model = {s.model_name: s for s in stats}
-        
+
         assert "claude-3-5-sonnet-20241022" in stats_by_model
         sonnet = stats_by_model["claude-3-5-sonnet-20241022"]
         assert sonnet.total_calls == 5
         assert len(sonnet.tool_stats) == 2
-        
+
         sonnet_tools = {t.tool_name: t for t in sonnet.tool_stats}
         assert "bash" in sonnet_tools
         assert sonnet_tools["bash"].total_calls == 3
         assert sonnet_tools["bash"].success_count == 2
         assert sonnet_tools["bash"].failure_count == 1
-        
+        assert sonnet_tools["bash"].input_tokens == 300
+        assert sonnet_tools["bash"].output_tokens == 150
+        assert sonnet_tools["bash"].cache_read_tokens == 600
+        assert sonnet_tools["bash"].cache_write_tokens == 30
+        assert sonnet_tools["bash"].total_tokens == 1080
+
+        assert sonnet_tools["read"].input_tokens == 200
+        assert sonnet_tools["read"].output_tokens == 100
+        assert sonnet_tools["read"].cache_read_tokens == 400
+        assert sonnet_tools["read"].cache_write_tokens == 20
+        assert sonnet_tools["read"].total_tokens == 720
+
         assert "claude-3-5-haiku-20240307" in stats_by_model
         haiku = stats_by_model["claude-3-5-haiku-20240307"]
         assert haiku.total_calls == 3
         assert len(haiku.tool_stats) == 1
-        
+
         haiku_tools = {t.tool_name: t for t in haiku.tool_stats}
         assert "edit" in haiku_tools
         assert haiku_tools["edit"].total_calls == 3
         assert haiku_tools["edit"].success_count == 1
         assert haiku_tools["edit"].failure_count == 2
+        assert haiku_tools["edit"].input_tokens == 90
+        assert haiku_tools["edit"].output_tokens == 30
+        assert haiku_tools["edit"].cache_read_tokens == 300
+        assert haiku_tools["edit"].cache_write_tokens == 60
+        assert haiku_tools["edit"].total_tokens == 480
 
     def test_excludes_running_status(self, temp_db_with_messages: Path):
         """Test that running status tools are excluded."""
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
+
         stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
             ["ses_model_test"], temp_db_with_messages
         )
-        
+
         haiku = next(s for s in stats if s.model_name == "claude-3-5-haiku-20240307")
-        
+
         bash_stat = next((t for t in haiku.tool_stats if t.tool_name == "bash"), None)
-        
+
         assert bash_stat is None
 
     def test_handles_nested_modelID(self, tmp_path: Path):
@@ -522,7 +561,7 @@ class TestLoadToolUsageByModelForSessions:
         db_path = tmp_path / "test_nested.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
+
         conn.execute("""
             CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, title TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL)
         """)
@@ -532,53 +571,73 @@ class TestLoadToolUsageByModelForSessions:
         conn.execute("""
             CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)
         """)
-        
-        conn.execute("INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_nested", "proj_1", None, "Nested Test", 1000, 2000))
-        
-        conn.execute("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
-            ("msg_nested", "ses_nested", 1000, 1000, json.dumps({"role": "assistant", "model": {"modelID": "nested-model-v1"}})))
-        
-        data = json.dumps({"type": "tool", "tool": "bash", "state": {"status": "completed"}})
-        conn.execute("INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_nested", "msg_nested", "ses_nested", 1000, 1000, data))
-        
+
+        conn.execute(
+            "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
+            ("ses_nested", "proj_1", None, "Nested Test", 1000, 2000),
+        )
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+            (
+                "msg_nested",
+                "ses_nested",
+                1000,
+                1000,
+                json.dumps(
+                    {"role": "assistant", "model": {"modelID": "nested-model-v1"}}
+                ),
+            ),
+        )
+
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "completed"}}
+        )
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+            ("prt_nested", "msg_nested", "ses_nested", 1000, 1000, data),
+        )
+
         conn.commit()
         conn.close()
-        
+
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
-        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(["ses_nested"], db_path)
-        
+
+        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
+            ["ses_nested"], db_path
+        )
+
         assert len(stats) == 1
         assert stats[0].model_name == "nested-model-v1"
 
     def test_empty_sessions_returns_empty(self, tmp_path: Path):
         """Test that empty session list returns empty list."""
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
-        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions([], tmp_path / "test.db")
+
+        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
+            [], tmp_path / "test.db"
+        )
         assert stats == []
 
     def test_sorts_models_by_total_calls(self, temp_db_with_messages: Path):
         """Test that models are sorted by total calls descending."""
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
+
         stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
             ["ses_model_test"], temp_db_with_messages
         )
-        
+
         assert stats[0].model_name == "claude-3-5-sonnet-20241022"
         assert stats[1].model_name == "claude-3-5-haiku-20240307"
 
     def test_sorts_tools_within_model(self, temp_db_with_messages: Path):
         """Test that tools within a model are sorted by total_calls descending."""
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
+
         stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
             ["ses_model_test"], temp_db_with_messages
         )
-        
+
         sonnet = next(s for s in stats if s.model_name == "claude-3-5-sonnet-20241022")
         assert sonnet.tool_stats[0].tool_name == "bash"
         assert sonnet.tool_stats[1].tool_name == "read"
@@ -588,27 +647,49 @@ class TestLoadToolUsageByModelForSessions:
         db_path = tmp_path / "test_unknown.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
-        conn.execute("CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, title TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL)")
-        conn.execute("CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)")
-        conn.execute("CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)")
-        
-        conn.execute("INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_unknown", "proj_1", None, "Unknown Test", 1000, 2000))
-        
-        conn.execute("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
-            ("msg_unknown", "ses_unknown", 1000, 1000, json.dumps({"role": "assistant"})))
-        
-        data = json.dumps({"type": "tool", "tool": "bash", "state": {"status": "completed"}})
-        conn.execute("INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_unknown", "msg_unknown", "ses_unknown", 1000, 1000, data))
-        
+
+        conn.execute(
+            "CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, title TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)"
+        )
+
+        conn.execute(
+            "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
+            ("ses_unknown", "proj_1", None, "Unknown Test", 1000, 2000),
+        )
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+            (
+                "msg_unknown",
+                "ses_unknown",
+                1000,
+                1000,
+                json.dumps({"role": "assistant"}),
+            ),
+        )
+
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "completed"}}
+        )
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+            ("prt_unknown", "msg_unknown", "ses_unknown", 1000, 1000, data),
+        )
+
         conn.commit()
         conn.close()
-        
+
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
-        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(["ses_unknown"], db_path)
-        
+
+        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
+            ["ses_unknown"], db_path
+        )
+
         assert len(stats) == 1
         assert stats[0].model_name == "unknown"


### PR DESCRIPTION
### Problem
The live dashboard showed workflow totals and tool counts, but it did not expose enough detail to understand token usage by model and tool. Per-tool token stats are also not stored directly by OpenCode: tokens live on assistant messages while tool executions are separate parts, so naive aggregation can double-count when a message triggers multiple tools.

### Changes
- Adds richer live dashboard model panels with total, input, output, cache read/write, cost, context, and output-rate details.
- Adds attributed per-tool token statistics in SQLite-backed live dashboards. When a message has multiple terminal tool calls, its tokens are split evenly across those tools to avoid double-counting.
- Compacts per-tool token display so dense multi-model dashboards remain readable.
- Adds `ocmonitor.sh` to run this checkout through its local virtualenv while forwarding all CLI commands and flags.

### Usage
```bash
./ocmonitor.sh live --pick
./ocmonitor.sh models
./ocmonitor.sh config show
```

### Verification
- `python3 -m py_compile ocmonitor/models/tool_usage.py ocmonitor/utils/sqlite_utils.py ocmonitor/ui/dashboard.py`
- `bash -n ocmonitor.sh`
- `pytest tests/unit/test_sqlite_tool_usage.py -q`
- `pytest tests/unit/test_live_monitor.py -q`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Token usage tracking now captures input, output, and cache metrics across tools and models
  * Enhanced dashboard displays detailed token counts, cache usage, and cost information per model and tool
  * Improved wrapper script for simplified command execution with automatic environment setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->