### PR TITLE
feat: add --last N flag to live command picker

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,74 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "@qalarc/qtk-plugin": "^0.3.1",
+      },
+    },
+  },
+  "packages": {
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.17.9", "", { "dependencies": { "@opencode-ai/sdk": "1.17.9", "effect": "4.0.0-beta.74", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.3.4", "@opentui/keymap": ">=0.3.4", "@opentui/solid": ">=0.3.4" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-RvYsX2k90ew0P3c0R/Jrt6UOdA5CYf4GmYuREDKHx31GSJ25WKg9hrTzkcwCfvPPCpaBc53Qq6Fon9aWr+58ag=="],
+
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.9", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-MHmXEpGPHkg14v1p+cUlIOUxd6DQdSElfau9nqY7tcDI0x5r4Y8D0dKXcyAh0Gc73ptaGW67Vg84nkcV6O27Pw=="],
+
+    "@qalarc/qtk-plugin": ["@qalarc/qtk-plugin@0.3.1", "", { "peerDependencies": { "@opencode-ai/plugin": "^1.1.0" } }, "sha512-kPR+Dk2tT8704tavQ522WpEJF6QxMdQiuGTaQdLL0EM6o2lCh9oLdpaUu65YRcxODPh4yzdl54cNebx8+OFNsA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "effect": ["effect@4.0.0-beta.74", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA=="],
+
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
+
+    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
+
+    "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
+    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+  }
+}

--- a/mock_session.py
+++ b/mock_session.py
@@ -1,0 +1,21 @@
+import os
+import json
+import time
+
+os.makedirs(".opencode_sessions/mock-session", exist_ok=True)
+with open(".opencode_sessions/mock-session/opencode_session_mock-session.json", "w") as f:
+    json.dump({
+        "timestamp": time.time() * 1000,
+        "model": "claude-3-5-sonnet-20241022",
+        "tokens": {
+            "input": 100,
+            "output": 200,
+            "cache_write": 0,
+            "cache_read": 0
+        },
+        "time_data": {
+            "duration_ms": 1000
+        }
+    }, f)
+
+print("Done")

--- a/ocmonitor.sh
+++ b/ocmonitor.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+if [[ ! -d .venv ]]; then
+  python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+
+if [[ ! -x .venv/bin/ocmonitor || "${OCMONITOR_REINSTALL:-0}" == "1" ]]; then
+  python -m pip install -e .
+fi
+
+if [[ "${OCMONITOR_WRAPPER_DEBUG:-0}" == "1" ]]; then
+  which ocmonitor
+  python - <<'PY'
+import ocmonitor.ui.dashboard as dashboard
+print(f"dashboard.py: {dashboard.__file__}")
+PY
+fi
+
+exec ocmonitor "$@"

--- a/ocmonitor/cli.py
+++ b/ocmonitor/cli.py
@@ -44,10 +44,14 @@ def parse_period(ctx, param, value):
     if value is not None:
         if param.name == "year":
             if not isinstance(value, str) or not value.isdigit() or len(value) != 4:
-                raise click.BadParameter("Year must be a valid YYYY format (e.g., 2024)")
+                raise click.BadParameter(
+                    "Year must be a valid YYYY format (e.g., 2024)"
+                )
             year_int = int(value)
             if year_int < 1:
-                raise click.BadParameter("Year must be a valid YYYY format (e.g., 2024)")
+                raise click.BadParameter(
+                    "Year must be a valid YYYY format (e.g., 2024)"
+                )
             return year_int
         return value
     return None
@@ -56,11 +60,11 @@ def parse_period(ctx, param, value):
 @contextmanager
 def cli_error_context(ctx: click.Context, operation_name: str):
     """Context manager for consistent CLI error handling across all commands.
-    
+
     Usage:
         with cli_error_context(ctx, "analyzing sessions"):
             result = perform_operation()
-    
+
     Args:
         ctx: Click context object containing verbose flag
         operation_name: Human-readable description of the operation (for error messages)
@@ -79,9 +83,9 @@ def cli_error_context(ctx: click.Context, operation_name: str):
 
 def handle_output_format(result: Any, output_format: str) -> None:
     """Handle output formatting for CLI results.
-    
+
     Centralizes JSON/CSV/table output logic used across multiple commands.
-    
+
     Args:
         result: The result data to output
         output_format: One of 'json', 'csv', or 'table'
@@ -96,21 +100,21 @@ def handle_output_format(result: Any, output_format: str) -> None:
 
 def resolve_path(path: Optional[str], default_to_messages_dir: bool = True) -> str:
     """Resolve path with appropriate default fallback.
-    
+
     Args:
         path: User-provided path or None
         default_to_messages_dir: If True, default to messages_dir; otherwise use cwd
-        
+
     Returns:
         Resolved path string
     """
     if path:
         return path
-    
+
     cfg = config_manager.config
     if default_to_messages_dir:
         return cfg.paths.messages_dir
-    
+
     return str(Path.cwd())
 
 
@@ -125,11 +129,19 @@ _REPORT_METHOD_MAP = {
     },
     "sessions": {
         "method": "generate_sessions_summary_report",
-        "params": {"base_path": _PATH_PLACEHOLDER, "limit": None, "output_format": "table"},
+        "params": {
+            "base_path": _PATH_PLACEHOLDER,
+            "limit": None,
+            "output_format": "table",
+        },
     },
     "daily": {
         "method": "generate_daily_report",
-        "params": {"base_path": _PATH_PLACEHOLDER, "month": None, "output_format": "table"},
+        "params": {
+            "base_path": _PATH_PLACEHOLDER,
+            "month": None,
+            "output_format": "table",
+        },
     },
     "weekly": {
         "method": "generate_weekly_report",
@@ -143,7 +155,11 @@ _REPORT_METHOD_MAP = {
     },
     "monthly": {
         "method": "generate_monthly_report",
-        "params": {"base_path": _PATH_PLACEHOLDER, "year": None, "output_format": "table"},
+        "params": {
+            "base_path": _PATH_PLACEHOLDER,
+            "year": None,
+            "output_format": "table",
+        },
     },
     "models": {
         "method": "generate_models_report",
@@ -174,7 +190,10 @@ _REPORT_METHOD_MAP = {
     "--config", "-c", type=click.Path(exists=True), help="Path to configuration file"
 )
 @click.option(
-    "--theme", "-t", type=click.Choice(["dark", "light"]), help="Set UI theme (overrides config)"
+    "--theme",
+    "-t",
+    type=click.Choice(["dark", "light"]),
+    help="Set UI theme (overrides config)",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
 @click.option(
@@ -219,11 +238,11 @@ def cli(
             config_manager.reload()
 
         cfg = config_manager.config
-        
+
         # Override theme if provided via CLI
         if theme:
             cfg.ui.theme = theme
-        
+
         # Resolve deprecated flag to the new split flags
         if no_remote:
             no_remote_pricing = True
@@ -232,7 +251,7 @@ def cli(
         # Store flags in context for later use
         ctx.obj["no_remote_pricing"] = no_remote_pricing
         ctx.obj["no_remote_rates"] = no_remote_rates
-            
+
         ctx.obj["config"] = cfg
         ctx.obj["pricing_data"] = config_manager.load_pricing_data(
             no_remote=no_remote_pricing
@@ -243,8 +262,10 @@ def cli(
         resolved_rate = None
         if currency_cfg.remote_rates and not no_remote_rates:
             from .services.rate_fetcher import get_exchange_rate
+
             resolved_rate = get_exchange_rate(currency_cfg)
         from .utils.currency import CurrencyConverter
+
         currency_converter = CurrencyConverter.from_config(currency_cfg, resolved_rate)
         ctx.obj["currency_converter"] = currency_converter
 
@@ -257,10 +278,17 @@ def cli(
         # Initialize services
         analyzer = SessionAnalyzer(ctx.obj["pricing_data"])
         ctx.obj["analyzer"] = analyzer
-        ctx.obj["report_generator"] = ReportGenerator(analyzer, console, currency_converter)
-        ctx.obj["export_service"] = ExportService(cfg.paths.export_dir, currency_converter)
+        ctx.obj["report_generator"] = ReportGenerator(
+            analyzer, console, currency_converter
+        )
+        ctx.obj["export_service"] = ExportService(
+            cfg.paths.export_dir, currency_converter
+        )
         ctx.obj["live_monitor"] = LiveMonitor(
-            ctx.obj["pricing_data"], console, paths_config=cfg.paths, currency_converter=currency_converter
+            ctx.obj["pricing_data"],
+            console,
+            paths_config=cfg.paths,
+            currency_converter=currency_converter,
         )
 
     except Exception as e:
@@ -287,7 +315,9 @@ def cli(
     help="Ignore stored OpenCode cost values and recalculate costs using current pricing config",
 )
 @click.pass_context
-def session(ctx: click.Context, path: Optional[str], output_format: str, recalculate: bool):
+def session(
+    ctx: click.Context, path: Optional[str], output_format: str, recalculate: bool
+):
     """Analyze a single OpenCode session directory.
 
     PATH: Path to session directory (defaults to current directory)
@@ -296,7 +326,9 @@ def session(ctx: click.Context, path: Optional[str], output_format: str, recalcu
 
     with cli_error_context(ctx, "analyzing session"):
         report_generator = ctx.obj["report_generator"]
-        result = report_generator.generate_single_session_report(path, output_format, recalculate)
+        result = report_generator.generate_single_session_report(
+            path, output_format, recalculate
+        )
 
         if result is None:
             click.echo(
@@ -324,10 +356,11 @@ def session(ctx: click.Context, path: Optional[str], output_format: str, recalcu
     "--no-group", is_flag=True, help="Show sessions without workflow grouping"
 )
 @click.option(
-    "--source", "-s",
+    "--source",
+    "-s",
     type=click.Choice(["auto", "sqlite", "files"]),
     default="auto",
-    help="Data source: auto (prefer SQLite), sqlite (v1.2.0+), or files (legacy)"
+    help="Data source: auto (prefer SQLite), sqlite (v1.2.0+), or files (legacy)",
 )
 @click.option(
     "--recalculate",
@@ -361,21 +394,33 @@ def sessions(
 
         # Get data source info
         source_info = analyzer.get_data_source_info()
-        console.print(f"[status.info]Using data source: {source_info['last_used'] or 'auto-detect'}[/status.info]")
+        console.print(
+            f"[status.info]Using data source: {source_info['last_used'] or 'auto-detect'}[/status.info]"
+        )
 
         if limit:
             sessions_list = analyzer.analyze_all_sessions(path, limit)
-            console.print(f"[status.info]Analyzing {len(sessions_list)} most recent sessions...[/status.info]")
+            console.print(
+                f"[status.info]Analyzing {len(sessions_list)} most recent sessions...[/status.info]"
+            )
         else:
             sessions_list = analyzer.analyze_all_sessions(path)
-            console.print(f"[status.info]Analyzing {len(sessions_list)} sessions...[/status.info]")
+            console.print(
+                f"[status.info]Analyzing {len(sessions_list)} sessions...[/status.info]"
+            )
 
         if not sessions_list:
-            console.print("[status.error]No sessions found in the specified directory.[/status.error]")
+            console.print(
+                "[status.error]No sessions found in the specified directory.[/status.error]"
+            )
             ctx.exit(1)
 
         result = report_generator.generate_sessions_summary_report(
-            path, limit, output_format, group_workflows=not no_group, force_recalculate=recalculate
+            path,
+            limit,
+            output_format,
+            group_workflows=not no_group,
+            force_recalculate=recalculate,
         )
 
         handle_output_format(result, output_format)
@@ -383,25 +428,27 @@ def sessions(
 
 def _determine_monitoring_source(source: str, validation: dict) -> tuple[bool, bool]:
     """Determine which monitoring source to use based on validation and user preference.
-    
+
     Args:
         source: User-specified source preference ("auto", "sqlite", or "files")
         validation: Validation result dict containing availability info
-        
+
     Returns:
         Tuple of (use_sqlite, use_files) booleans
     """
     sqlite_available = validation["info"]["sqlite"]["available"]
     files_available = validation["info"]["files"].get("available", False)
-    
+
     use_sqlite = (source == "sqlite") or (source == "auto" and sqlite_available)
-    use_files = (source == "files") or (source == "auto" and not sqlite_available and files_available)
-    
+    use_files = (source == "files") or (
+        source == "auto" and not sqlite_available and files_available
+    )
+
     return use_sqlite, use_files
 
 
 def _prompt_workflow_selection(
-    live_monitor: LiveMonitor,
+    live_monitor,
     use_sqlite: bool,
     use_files: bool,
     sqlite_available: bool,
@@ -411,9 +458,10 @@ def _prompt_workflow_selection(
     pick: bool,
     console,
     config,
+    last: Optional[int] = None,
 ) -> tuple[Optional[str], str]:
     """Prompt user to select a workflow for monitoring.
-    
+
     Args:
         live_monitor: LiveMonitor instance
         use_sqlite: Whether to use SQLite mode
@@ -425,7 +473,8 @@ def _prompt_workflow_selection(
         pick: Whether to prompt for workflow selection
         console: Rich console instance
         config: Configuration instance
-        
+        last: Limit number of workflows shown in picker (most recent N only)
+
     Returns:
         Tuple of (selected_session_id, mode) where mode is "sqlite", "files",
         "cancelled" (user dismissed picker), or "" (no data source available).
@@ -435,9 +484,11 @@ def _prompt_workflow_selection(
 
     if use_sqlite and sqlite_available:
         if pick and not selected_session_id:
-            selected_session_id = live_monitor.pick_sqlite_workflow()
+            selected_session_id = live_monitor.pick_sqlite_workflow(last=last)
             if not selected_session_id:
-                console.print("[status.warning]No workflow selected. Exiting.[/status.warning]")
+                console.print(
+                    "[status.warning]No workflow selected. Exiting.[/status.warning]"
+                )
                 return None, "cancelled"
         return selected_session_id, "sqlite"
 
@@ -446,9 +497,11 @@ def _prompt_workflow_selection(
             path = config.paths.messages_dir
         if pick and not selected_session_id:
             assert path is not None
-            selected_session_id = live_monitor.pick_file_workflow(path)
+            selected_session_id = live_monitor.pick_file_workflow(path, last=last)
             if not selected_session_id:
-                console.print("[status.warning]No workflow selected. Exiting.[/status.warning]")
+                console.print(
+                    "[status.warning]No workflow selected. Exiting.[/status.warning]"
+                )
                 return None, "cancelled"
         return selected_session_id, "files"
 
@@ -457,12 +510,12 @@ def _prompt_workflow_selection(
 
 def _display_validation_results(console, validation: dict, ctx) -> bool:
     """Display validation results and exit if critical errors found.
-    
+
     Args:
         console: Rich console instance
         validation: Validation result dict
         ctx: Click context for exiting
-        
+
     Returns:
         True if validation passed, False if ctx.exit was called
     """
@@ -471,11 +524,11 @@ def _display_validation_results(console, validation: dict, ctx) -> bool:
             console.print(f"[status.error]Error: {issue}[/status.error]")
         ctx.exit(1)
         return False
-    
+
     if validation["warnings"]:
         for warning in validation["warnings"]:
             console.print(f"[status.warning]Warning: {warning}[/status.warning]")
-    
+
     return True
 
 
@@ -501,10 +554,17 @@ def _display_validation_results(console, validation: dict, ctx) -> bool:
     help="Enable in-dashboard workflow switching controls (experimental)",
 )
 @click.option(
-    "--source", "-s",
+    "--source",
+    "-s",
     type=click.Choice(["auto", "sqlite", "files"]),
     default="auto",
-    help="Data source: auto (prefer SQLite), sqlite (v1.2.0+), or files (legacy)"
+    help="Data source: auto (prefer SQLite), sqlite (v1.2.0+), or files (legacy)",
+)
+@click.option(
+    "--last",
+    type=int,
+    default=None,
+    help="Limit the number of workflows shown in the picker (most recent N only)",
 )
 @click.pass_context
 def live(
@@ -516,6 +576,7 @@ def live(
     session_id: Optional[str],
     interactive_switch: bool,
     source: str,
+    last: Optional[int],
 ):
     """Start live dashboard for monitoring the current workflow.
 
@@ -546,10 +607,10 @@ def live(
 
         sqlite_available = validation["info"]["sqlite"]["available"]
         files_available = validation["info"]["files"].get("available", False)
-        
+
         # Determine which monitoring method to use
         use_sqlite, use_files = _determine_monitoring_source(source, validation)
-        
+
         # Prompt for workflow selection
         selected_session_id, mode = _prompt_workflow_selection(
             live_monitor,
@@ -562,10 +623,13 @@ def live(
             pick,
             console,
             config,
+            last=last,
         )
-        
+
         if mode == "":
-            console.print("[status.error]No data source available. Please check OpenCode installation.[/status.error]")
+            console.print(
+                "[status.error]No data source available. Please check OpenCode installation.[/status.error]"
+            )
             ctx.exit(1)
             return
 
@@ -582,7 +646,9 @@ def live(
         elif mode == "files":
             if not path:
                 path = config.paths.messages_dir
-            console.print("[status.success]Starting workflow live dashboard (legacy file mode)[/status.success]")
+            console.print(
+                "[status.success]Starting workflow live dashboard (legacy file mode)[/status.success]"
+            )
             console.print(f"[status.info]Monitoring: {path}[/status.info]")
             console.print(f"[status.info]Update interval: {interval}s[/status.info]")
             live_monitor.start_monitoring(
@@ -604,11 +670,23 @@ def live(
 
 @cli.command()
 @click.argument("path", type=click.Path(exists=True), required=False)
-@click.option("--month", is_flag=False, flag_value="LAST_N_DAYS", default=None, callback=parse_period,
-              help="Month to analyze (YYYY-MM format) or bare for last 30 days")
+@click.option(
+    "--month",
+    is_flag=False,
+    flag_value="LAST_N_DAYS",
+    default=None,
+    callback=parse_period,
+    help="Month to analyze (YYYY-MM format) or bare for last 30 days",
+)
 @click.option("--week", "last_week", is_flag=True, help="Show last 7 days")
-@click.option("--year", is_flag=False, flag_value="LAST_N_DAYS", default=None, callback=parse_period,
-              help="Year to analyze (YYYY) or bare for last 365 days")
+@click.option(
+    "--year",
+    is_flag=False,
+    flag_value="LAST_N_DAYS",
+    default=None,
+    callback=parse_period,
+    help="Year to analyze (YYYY) or bare for last 365 days",
+)
 @click.option(
     "--format",
     "-f",
@@ -654,7 +732,9 @@ def daily(
     if year is not None:
         period_opts += 1
     if period_opts > 1:
-        raise click.UsageError("Options --week, --month, and --year are mutually exclusive")
+        raise click.UsageError(
+            "Options --week, --month, and --year are mutually exclusive"
+        )
 
     last_n_days = None
     year_filter = None
@@ -670,7 +750,13 @@ def daily(
     with cli_error_context(ctx, "generating daily breakdown"):
         report_generator = ctx.obj["report_generator"]
         result = report_generator.generate_daily_report(
-            path, None if month == "LAST_N_DAYS" else month, output_format, breakdown, last_n_days, year_filter, recalculate
+            path,
+            None if month == "LAST_N_DAYS" else month,
+            output_format,
+            breakdown,
+            last_n_days,
+            year_filter,
+            recalculate,
         )
 
         handle_output_format(result, output_format)
@@ -678,10 +764,22 @@ def daily(
 
 @cli.command()
 @click.argument("path", type=click.Path(exists=True), required=False)
-@click.option("--year", is_flag=False, flag_value="LAST_N_DAYS", default=None, callback=parse_period,
-              help="Year to analyze (YYYY) or bare for last 365 days")
-@click.option("--month", is_flag=False, flag_value="LAST_N_DAYS", default=None, callback=parse_period,
-              help="Month to analyze (YYYY-MM) or bare for last 30 days")
+@click.option(
+    "--year",
+    is_flag=False,
+    flag_value="LAST_N_DAYS",
+    default=None,
+    callback=parse_period,
+    help="Year to analyze (YYYY) or bare for last 365 days",
+)
+@click.option(
+    "--month",
+    is_flag=False,
+    flag_value="LAST_N_DAYS",
+    default=None,
+    callback=parse_period,
+    help="Month to analyze (YYYY-MM) or bare for last 30 days",
+)
 @click.option(
     "--start-day",
     type=click.Choice(
@@ -750,7 +848,14 @@ def weekly(
     with cli_error_context(ctx, "generating weekly breakdown"):
         report_generator = ctx.obj["report_generator"]
         result = report_generator.generate_weekly_report(
-            path, year_filter, month_filter, output_format, breakdown, week_start_day, last_n_days, recalculate
+            path,
+            year_filter,
+            month_filter,
+            output_format,
+            breakdown,
+            week_start_day,
+            last_n_days,
+            recalculate,
         )
 
         handle_output_format(result, output_format)
@@ -758,8 +863,14 @@ def weekly(
 
 @cli.command()
 @click.argument("path", type=click.Path(exists=True), required=False)
-@click.option("--year", is_flag=False, flag_value="LAST_N_DAYS", default=None, callback=parse_period,
-              help="Year to analyze (YYYY) or bare for last 365 days")
+@click.option(
+    "--year",
+    is_flag=False,
+    flag_value="LAST_N_DAYS",
+    default=None,
+    callback=parse_period,
+    help="Year to analyze (YYYY) or bare for last 365 days",
+)
 @click.option(
     "--format",
     "-f",
@@ -938,46 +1049,48 @@ def projects(
         handle_output_format(result, output_format)
 
 
-def _generate_export_report(report_type: str, path: Optional[str], report_generator, force_recalculate: bool = False) -> Optional[dict]:
+def _generate_export_report(
+    report_type: str,
+    path: Optional[str],
+    report_generator,
+    force_recalculate: bool = False,
+) -> Optional[dict]:
     """Generate report data for export based on report type.
-    
+
     Args:
         report_type: Type of report to generate
         path: Path to analyze
         report_generator: ReportGenerator instance
         force_recalculate: If True, ignore stored costs and recalculate from pricing data
-        
+
     Returns:
         Report data dictionary or None if report type is invalid
     """
     if report_type not in _REPORT_METHOD_MAP:
         return None
-    
+
     report_config = _REPORT_METHOD_MAP[report_type]
     method_name = report_config["method"]
     params = report_config["params"].copy()
-    
+
     # Replace path placeholders with actual path value
     for key in params:
         if params[key] is _PATH_PLACEHOLDER:
             params[key] = path
-    
+
     # Add force_recalculate parameter
     params["force_recalculate"] = force_recalculate
-    
+
     # Get the method from report_generator and call it with unpacked params
     method = getattr(report_generator, method_name)
     return method(**params)
 
 
 def _display_export_summary(
-    console, 
-    output_path: str, 
-    export_service, 
-    report_type: str
+    console, output_path: str, export_service, report_type: str
 ) -> None:
     """Display export completion summary.
-    
+
     Args:
         console: Rich console instance
         output_path: Path to the exported file
@@ -986,10 +1099,16 @@ def _display_export_summary(
     """
     summary = export_service.get_export_summary(output_path)
     console.print(f"[status.success]✅ Export completed successfully![/status.success]")
-    console.print(f"[metric.label]File:[/metric.label] [metric.value]{output_path}[/metric.value]")
-    console.print(f"[metric.label]Size:[/metric.label] [metric.value]{summary.get('size_human', 'Unknown')}[/metric.value]")
+    console.print(
+        f"[metric.label]File:[/metric.label] [metric.value]{output_path}[/metric.value]"
+    )
+    console.print(
+        f"[metric.label]Size:[/metric.label] [metric.value]{summary.get('size_human', 'Unknown')}[/metric.value]"
+    )
     if "rows" in summary:
-        console.print(f"[metric.label]Rows:[/metric.label] [metric.value]{summary['rows']}[/metric.value]")
+        console.print(
+            f"[metric.label]Rows:[/metric.label] [metric.value]{summary['rows']}[/metric.value]"
+        )
 
 
 @cli.command()
@@ -1042,7 +1161,9 @@ def export(
         export_service = ctx.obj["export_service"]
 
         # Generate report data using method mapping
-        report_data = _generate_export_report(report_type, path, report_generator, recalculate)
+        report_data = _generate_export_report(
+            report_type, path, report_generator, recalculate
+        )
 
         if not report_data:
             console.print("[status.error]No data to export.[/status.error]")
@@ -1079,32 +1200,68 @@ def config_show(ctx: click.Context):
         console.print("[table.title]📋 Current Configuration:[/table.title]")
         console.print()
         console.print("[table.header]📁 Paths:[/table.header]")
-        console.print(f"  [metric.label]Database file:[/metric.label] [metric.value]{config.paths.database_file}[/metric.value]")
-        console.print(f"  [metric.label]Messages directory:[/metric.label] [metric.value]{config.paths.messages_dir}[/metric.value]")
-        console.print(f"  [metric.label]Export directory:[/metric.label] [metric.value]{config.paths.export_dir}[/metric.value]")
+        console.print(
+            f"  [metric.label]Database file:[/metric.label] [metric.value]{config.paths.database_file}[/metric.value]"
+        )
+        console.print(
+            f"  [metric.label]Messages directory:[/metric.label] [metric.value]{config.paths.messages_dir}[/metric.value]"
+        )
+        console.print(
+            f"  [metric.label]Export directory:[/metric.label] [metric.value]{config.paths.export_dir}[/metric.value]"
+        )
         console.print()
         console.print("[table.header]🎨 UI Settings:[/table.header]")
-        console.print(f"  [metric.label]Table style:[/metric.label] [metric.value]{config.ui.table_style}[/metric.value]")
-        console.print(f"  [metric.label]Theme:[/metric.label] [metric.value]{config.ui.theme}[/metric.value]")
-        console.print(f"  [metric.label]Progress bars:[/metric.label] [metric.value]{config.ui.progress_bars}[/metric.value]")
-        console.print(f"  [metric.label]Colors:[/metric.label] [metric.value]{config.ui.colors}[/metric.value]")
-        console.print(f"  [metric.label]Live refresh interval:[/metric.label] [metric.value]{config.ui.live_refresh_interval}s[/metric.value]")
+        console.print(
+            f"  [metric.label]Table style:[/metric.label] [metric.value]{config.ui.table_style}[/metric.value]"
+        )
+        console.print(
+            f"  [metric.label]Theme:[/metric.label] [metric.value]{config.ui.theme}[/metric.value]"
+        )
+        console.print(
+            f"  [metric.label]Progress bars:[/metric.label] [metric.value]{config.ui.progress_bars}[/metric.value]"
+        )
+        console.print(
+            f"  [metric.label]Colors:[/metric.label] [metric.value]{config.ui.colors}[/metric.value]"
+        )
+        console.print(
+            f"  [metric.label]Live refresh interval:[/metric.label] [metric.value]{config.ui.live_refresh_interval}s[/metric.value]"
+        )
         console.print()
         console.print("[table.header]📤 Export Settings:[/table.header]")
-        console.print(f"  [metric.label]Default format:[/metric.label] [metric.value]{config.export.default_format}[/metric.value]")
-        console.print(f"  [metric.label]Include metadata:[/metric.label] [metric.value]{config.export.include_metadata}[/metric.value]")
+        console.print(
+            f"  [metric.label]Default format:[/metric.label] [metric.value]{config.export.default_format}[/metric.value]"
+        )
+        console.print(
+            f"  [metric.label]Include metadata:[/metric.label] [metric.value]{config.export.include_metadata}[/metric.value]"
+        )
         console.print()
         console.print("[table.header]💱 Currency:[/table.header]")
-        console.print(f"  [metric.label]Code:[/metric.label] [metric.value]{config.currency.code}[/metric.value]")
-        console.print(f"  [metric.label]Symbol:[/metric.label] [metric.value]{config.currency.symbol}[/metric.value]")
-        console.print(f"  [metric.label]Rate (from USD):[/metric.label] [metric.value]{config.currency.rate}[/metric.value]")
-        console.print(f"  [metric.label]Display format:[/metric.label] [metric.value]{config.currency.display_format}[/metric.value]")
-        decimals_display = "auto" if config.currency.decimals is None else config.currency.decimals
-        console.print(f"  [metric.label]Decimals:[/metric.label] [metric.value]{decimals_display}[/metric.value]")
-        console.print(f"  [metric.label]Remote rates:[/metric.label] [metric.value]{config.currency.remote_rates}[/metric.value]")
+        console.print(
+            f"  [metric.label]Code:[/metric.label] [metric.value]{config.currency.code}[/metric.value]"
+        )
+        console.print(
+            f"  [metric.label]Symbol:[/metric.label] [metric.value]{config.currency.symbol}[/metric.value]"
+        )
+        console.print(
+            f"  [metric.label]Rate (from USD):[/metric.label] [metric.value]{config.currency.rate}[/metric.value]"
+        )
+        console.print(
+            f"  [metric.label]Display format:[/metric.label] [metric.value]{config.currency.display_format}[/metric.value]"
+        )
+        decimals_display = (
+            "auto" if config.currency.decimals is None else config.currency.decimals
+        )
+        console.print(
+            f"  [metric.label]Decimals:[/metric.label] [metric.value]{decimals_display}[/metric.value]"
+        )
+        console.print(
+            f"  [metric.label]Remote rates:[/metric.label] [metric.value]{config.currency.remote_rates}[/metric.value]"
+        )
         console.print()
         console.print("[table.header]🤖 Models:[/table.header]")
-        console.print(f"  [metric.label]Configured models:[/metric.label] [metric.value]{len(pricing_data)}[/metric.value]")
+        console.print(
+            f"  [metric.label]Configured models:[/metric.label] [metric.value]{len(pricing_data)}[/metric.value]"
+        )
         for model_name in sorted(pricing_data.keys()):
             console.print(f"    - [table.row.model]{model_name}[/table.row.model]")
 
@@ -1125,10 +1282,16 @@ def config_set(ctx: click.Context, key: str, value: str):
 
 
 @cli.command()
-@click.option("--port", "-p", type=int, default=None,
-              help="Port to serve metrics on (default: 9090)")
-@click.option("--host", type=str, default=None,
-              help="Host to bind to (default: 0.0.0.0)")
+@click.option(
+    "--port",
+    "-p",
+    type=int,
+    default=None,
+    help="Port to serve metrics on (default: 9090)",
+)
+@click.option(
+    "--host", type=str, default=None, help="Host to bind to (default: 0.0.0.0)"
+)
 @click.pass_context
 def metrics(ctx, port, host):
     """Start a Prometheus metrics endpoint.
@@ -1153,8 +1316,12 @@ def metrics(ctx, port, host):
         return
 
     try:
-        console.print(f"[status.success]Starting Prometheus metrics server...[/status.success]")
-        console.print(f"[metric.label]Endpoint:[/metric.label] [metric.value]http://{host}:{port}/metrics[/metric.value]")
+        console.print(
+            f"[status.success]Starting Prometheus metrics server...[/status.success]"
+        )
+        console.print(
+            f"[metric.label]Endpoint:[/metric.label] [metric.value]http://{host}:{port}/metrics[/metric.value]"
+        )
         console.print("[dim]Press Ctrl+C to stop.[/dim]")
 
         server = MetricsServer(ctx.obj["pricing_data"], host=host, port=port)
@@ -1163,7 +1330,10 @@ def metrics(ctx, port, host):
         console.print("\n[status.warning]Metrics server stopped.[/status.warning]")
     except OSError as e:
         if e.errno == errno.EADDRINUSE:
-            click.echo(f"Port {port} is already in use. Try a different port with --port.", err=True)
+            click.echo(
+                f"Port {port} is already in use. Try a different port with --port.",
+                err=True,
+            )
         else:
             click.echo(f"Error starting metrics server: {e}", err=True)
         ctx.exit(1)
@@ -1189,12 +1359,16 @@ def agents(ctx: click.Context):
         registry = AgentRegistry()
         console = ctx.obj["console"]
 
-        console.print("[table.header]Main agents[/table.header] [dim](stay in same session)[/dim]:")
+        console.print(
+            "[table.header]Main agents[/table.header] [dim](stay in same session)[/dim]:"
+        )
         for agent in sorted(registry.get_all_main_agents()):
             console.print(f"  - [table.row.main]{agent}[/table.row.main]")
 
         console.print()
-        console.print("[table.header]Sub-agents[/table.header] [dim](create separate sessions)[/dim]:")
+        console.print(
+            "[table.header]Sub-agents[/table.header] [dim](create separate sessions)[/dim]:"
+        )
         for agent in sorted(registry.get_all_sub_agents()):
             console.print(f"  - [table.row.model]{agent}[/table.row.model]")
 

--- a/ocmonitor/models/session.py
+++ b/ocmonitor/models/session.py
@@ -294,8 +294,9 @@ class SessionData(BaseModel):
                 model_cost += file.calculate_cost(pricing_data, force_recalculate)
                 if file.time_data and file.time_data.duration_ms:
                     model_duration_ms += file.time_data.duration_ms
-                if file.is_rate_eligible:
-                    rate = file.tokens.output / (file.time_data.duration_ms / 1000)
+                duration_ms = file.time_data.duration_ms if file.time_data else None
+                if file.is_rate_eligible and duration_ms:
+                    rate = file.tokens.output / (duration_ms / 1000)
                     interaction_rates.append(rate)
 
             breakdown[display_model] = {
@@ -305,6 +306,48 @@ class SessionData(BaseModel):
                 'duration_ms': model_duration_ms,
                 'interaction_rates': interaction_rates,
             }
+
+        return breakdown
+
+    @staticmethod
+    def agent_model_key(agent: Optional[str], model: str) -> str:
+        """Build a stable live-dashboard grouping key for an agent/model pair."""
+        return f"{agent or 'main'}::{model}"
+
+    def get_agent_model_breakdown(self, pricing_data: Dict[str, Any], force_recalculate: bool = False) -> Dict[str, Dict[str, Any]]:
+        """Get live-dashboard usage breakdown by agent and model.
+
+        This leaves regular model reports unchanged while letting live dashboards
+        split the same model into separate agent-specific panes.
+        """
+        breakdown: Dict[str, Dict[str, Any]] = {}
+
+        for file in self.files:
+            key = self.agent_model_key(file.agent, file.display_model)
+            if key not in breakdown:
+                breakdown[key] = {
+                    'agent': file.agent or 'main',
+                    'model': file.display_model,
+                    'files': 0,
+                    'tokens': TokenUsage(),
+                    'cost': Decimal('0.0'),
+                    'duration_ms': 0,
+                    'interaction_rates': [],
+                }
+
+            stats = breakdown[key]
+            tokens = stats['tokens']
+            tokens.input += file.tokens.input
+            tokens.output += file.tokens.output
+            tokens.cache_write += file.tokens.cache_write
+            tokens.cache_read += file.tokens.cache_read
+            stats['files'] += 1
+            stats['cost'] += file.calculate_cost(pricing_data, force_recalculate)
+            if file.time_data and file.time_data.duration_ms:
+                stats['duration_ms'] += file.time_data.duration_ms
+            duration_ms = file.time_data.duration_ms if file.time_data else None
+            if file.is_rate_eligible and duration_ms:
+                stats['interaction_rates'].append(file.tokens.output / (duration_ms / 1000))
 
         return breakdown
 

--- a/ocmonitor/models/tool_usage.py
+++ b/ocmonitor/models/tool_usage.py
@@ -1,6 +1,6 @@
 """Tool usage models for OpenCode Monitor."""
 
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel, computed_field
 
 
@@ -78,6 +78,7 @@ class ModelToolUsage(BaseModel):
     """Tool usage statistics grouped by model."""
 
     model_name: str
+    agent_name: Optional[str] = None
     tool_stats: List[ToolUsageStats] = []
 
     @computed_field

--- a/ocmonitor/models/tool_usage.py
+++ b/ocmonitor/models/tool_usage.py
@@ -6,10 +6,15 @@ from pydantic import BaseModel, computed_field
 
 class ToolUsageStats(BaseModel):
     """Statistics for a single tool's usage."""
+
     tool_name: str
     total_calls: int = 0
     success_count: int = 0
     failure_count: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
 
     @computed_field
     @property
@@ -19,9 +24,21 @@ class ToolUsageStats(BaseModel):
             return 0.0
         return (self.success_count / self.total_calls) * 100.0
 
+    @computed_field
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens attributed to this tool."""
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_read_tokens
+            + self.cache_write_tokens
+        )
+
 
 class ToolUsageSummary(BaseModel):
     """Summary of all tool usage across sessions."""
+
     tool_stats: List[ToolUsageStats] = []
 
     @computed_field
@@ -50,9 +67,16 @@ class ToolUsageSummary(BaseModel):
             return 0.0
         return (self.total_success / self.total_calls) * 100.0
 
+    @computed_field
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens attributed across all tools."""
+        return sum(t.total_tokens for t in self.tool_stats)
+
 
 class ModelToolUsage(BaseModel):
     """Tool usage statistics grouped by model."""
+
     model_name: str
     tool_stats: List[ToolUsageStats] = []
 
@@ -61,3 +85,9 @@ class ModelToolUsage(BaseModel):
     def total_calls(self) -> int:
         """Total tool calls for this model."""
         return sum(t.total_calls for t in self.tool_stats)
+
+    @computed_field
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens attributed to tools for this model."""
+        return sum(t.total_tokens for t in self.tool_stats)

--- a/ocmonitor/services/live_monitor.py
+++ b/ocmonitor/services/live_monitor.py
@@ -1193,9 +1193,10 @@ class LiveMonitor:
         model_files: Dict[str, List[InteractionFile]] = {}
         for session in workflow.all_sessions:
             for f in session.non_zero_token_files:
-                if f.model_id not in model_files:
-                    model_files[f.model_id] = []
-                model_files[f.model_id].append(f)
+                key = SessionData.agent_model_key(f.agent, f.model_id)
+                if key not in model_files:
+                    model_files[key] = []
+                model_files[key].append(f)
 
         if not model_files:
             return {}
@@ -1228,10 +1229,11 @@ class LiveMonitor:
 
         model_most_recent: Dict[str, InteractionFile] = {}
         for f in all_files:
-            if f.model_id not in model_most_recent:
-                model_most_recent[f.model_id] = f
-            elif f.modification_time > model_most_recent[f.model_id].modification_time:
-                model_most_recent[f.model_id] = f
+            key = SessionData.agent_model_key(f.agent, f.model_id)
+            if key not in model_most_recent:
+                model_most_recent[key] = f
+            elif f.modification_time > model_most_recent[key].modification_time:
+                model_most_recent[key] = f
 
         result = {}
         default_context_window = 200000
@@ -1882,9 +1884,10 @@ class LiveMonitor:
         model_files: Dict[str, List[InteractionFile]] = {}
         for session in workflow["all_sessions"]:
             for f in session.non_zero_token_files:
-                if f.model_id not in model_files:
-                    model_files[f.model_id] = []
-                model_files[f.model_id].append(f)
+                key = SessionData.agent_model_key(f.agent, f.model_id)
+                if key not in model_files:
+                    model_files[key] = []
+                model_files[key].append(f)
 
         if not model_files:
             return {}
@@ -1917,17 +1920,18 @@ class LiveMonitor:
 
         model_most_recent: Dict[str, Any] = {}
         for f in all_files:
-            if f.model_id not in model_most_recent:
-                model_most_recent[f.model_id] = f
+            key = SessionData.agent_model_key(f.agent, f.model_id)
+            if key not in model_most_recent:
+                model_most_recent[key] = f
             elif f.time_data and f.time_data.created:
-                existing = model_most_recent[f.model_id]
+                existing = model_most_recent[key]
                 existing_time = (
                     existing.time_data.created
                     if existing.time_data and existing.time_data.created
                     else 0
                 )
                 if f.time_data.created > existing_time:
-                    model_most_recent[f.model_id] = f
+                    model_most_recent[key] = f
 
         result = {}
         default_context_window = 200000

--- a/ocmonitor/services/live_monitor.py
+++ b/ocmonitor/services/live_monitor.py
@@ -207,9 +207,20 @@ class LiveMonitor:
         base_path: str,
         allow_fallback: bool = True,
         selected_session_id: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> List[SessionWorkflow]:
-        """Load active file-based workflows, optionally falling back to most recent ones."""
-        sessions = FileProcessor.load_all_sessions(base_path, limit=50)
+        """Load active file-based workflows, optionally falling back to most recent ones.
+
+        Args:
+            base_path: Path to session directories.
+            allow_fallback: Whether to include recent historical workflows.
+            selected_session_id: Optional workflow ID to pin.
+            limit: Maximum number of workflows to return. Defaults to 5.
+        """
+        # Load enough sessions to produce the requested number of workflows.
+        # Since multiple sessions group into one workflow, scale up the session limit.
+        sessions_limit = (limit * 10) if limit is not None else 50
+        sessions = FileProcessor.load_all_sessions(base_path, limit=sessions_limit)
         if not sessions:
             return []
 
@@ -246,14 +257,23 @@ class LiveMonitor:
                 active_workflows.append(w)
                 seen_ids.add(w.workflow_id)
 
+        if limit is not None and limit > 0:
+            return active_workflows[:limit]
         return active_workflows[:5]
 
     def _get_sqlite_active_workflows(
         self,
         allow_fallback: bool = True,
         selected_session_id: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
-        """Load active SQLite workflows, optionally falling back to most recent ones."""
+        """Load active SQLite workflows, optionally falling back to most recent ones.
+
+        Args:
+            allow_fallback: Whether to include recent historical workflows.
+            selected_session_id: Optional workflow ID to pin.
+            limit: Maximum number of workflows to return. Defaults to 5.
+        """
         db_path = SQLiteProcessor.find_database_path()
         if not db_path:
             return []
@@ -285,13 +305,16 @@ class LiveMonitor:
             return active_workflows
 
         # Combine active and recent workflows, avoiding duplicates (by workflow_id)
-        recent = SQLiteProcessor.get_recent_workflows(db_path, limit=5)
+        recent_limit = limit if limit is not None else 5
+        recent = SQLiteProcessor.get_recent_workflows(db_path, limit=recent_limit)
         seen_ids = {w["workflow_id"] for w in active_workflows}
         for r in recent:
             if r["workflow_id"] not in seen_ids:
                 active_workflows.append(r)
                 seen_ids.add(r["workflow_id"])
 
+        if limit is not None and limit > 0:
+            return active_workflows[:limit]
         return active_workflows[:5]
 
     def _get_latest_sqlite_activity_ts(self, workflow: Dict[str, Any]) -> float:
@@ -477,17 +500,28 @@ class LiveMonitor:
                 continue
             return str(descriptors[selected_idx - 1]["workflow_id"])
 
-    def pick_sqlite_workflow(self) -> Optional[str]:
-        """Interactive SQLite workflow picker."""
-        workflows = self._get_sqlite_active_workflows()
+    def pick_sqlite_workflow(self, last: Optional[int] = None) -> Optional[str]:
+        """Interactive SQLite workflow picker.
+
+        Args:
+            last: Limit number of workflows shown (most recent N only).
+        """
+        workflows = self._get_sqlite_active_workflows(limit=last)
         descriptors = self._describe_sqlite_workflows(workflows)
         return self._prompt_for_workflow_selection(
             descriptors, "Select Workflow (SQLite Live Monitor)"
         )
 
-    def pick_file_workflow(self, base_path: str) -> Optional[str]:
-        """Interactive file workflow picker."""
-        workflows = self._get_file_active_workflows(base_path)
+    def pick_file_workflow(
+        self, base_path: str, last: Optional[int] = None
+    ) -> Optional[str]:
+        """Interactive file workflow picker.
+
+        Args:
+            base_path: Path to session directories.
+            last: Limit number of workflows shown (most recent N only).
+        """
+        workflows = self._get_file_active_workflows(base_path, limit=last)
         descriptors = self._describe_file_workflows(workflows)
         return self._prompt_for_workflow_selection(
             descriptors, "Select Workflow (File Live Monitor)"
@@ -2061,9 +2095,7 @@ class LiveMonitor:
 
         return 0.0
 
-    def _calculate_workflow_output_rate(
-        self, sessions: List[SessionData]
-    ) -> float:
+    def _calculate_workflow_output_rate(self, sessions: List[SessionData]) -> float:
         """Calculate p50 output token rate over the last 5 minutes across sessions.
 
         Pools interactions from every session in a workflow and mirrors the

--- a/ocmonitor/services/live_monitor.py
+++ b/ocmonitor/services/live_monitor.py
@@ -197,9 +197,12 @@ class LiveMonitor:
         return cast(Optional[ModelPricing], pricing)
 
     def _get_file_active_workflows(
-        self, base_path: str, allow_fallback: bool = True
+        self,
+        base_path: str,
+        allow_fallback: bool = True,
+        selected_session_id: Optional[str] = None,
     ) -> List[SessionWorkflow]:
-        """Load active file-based workflows, optionally falling back to most recent."""
+        """Load active file-based workflows, optionally falling back to most recent ones."""
         sessions = FileProcessor.load_all_sessions(base_path, limit=50)
         if not sessions:
             return []
@@ -209,27 +212,81 @@ class LiveMonitor:
             return []
 
         active_workflows = [w for w in workflows if w.end_time is None]
-        if active_workflows:
+
+        # Pinned mode should only consider active workflows plus the selected
+        # workflow itself. Do not pad with unrelated historical workflows.
+        if selected_session_id:
+            selected_wf = None
+            for w in workflows:
+                if w.workflow_id == selected_session_id or any(
+                    s.session_id == selected_session_id for s in w.all_sessions
+                ):
+                    selected_wf = w
+                    break
+
+            if selected_wf and selected_wf.workflow_id not in {
+                w.workflow_id for w in active_workflows
+            }:
+                return active_workflows + [selected_wf]
             return active_workflows
-        return workflows[:1] if allow_fallback else []
+
+        if not allow_fallback:
+            return active_workflows
+
+        # Combine active and all workflows, avoiding duplicates (by workflow_id)
+        seen_ids = {w.workflow_id for w in active_workflows}
+        for w in workflows:
+            if w.workflow_id not in seen_ids:
+                active_workflows.append(w)
+                seen_ids.add(w.workflow_id)
+
+        return active_workflows[:5]
 
     def _get_sqlite_active_workflows(
-        self, allow_fallback: bool = True
+        self,
+        allow_fallback: bool = True,
+        selected_session_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """Load active SQLite workflows, optionally falling back to most recent."""
+        """Load active SQLite workflows, optionally falling back to most recent ones."""
         db_path = SQLiteProcessor.find_database_path()
         if not db_path:
             return []
 
         active_workflows = SQLiteProcessor.get_all_active_workflows(db_path)
-        if active_workflows:
+
+        # Pinned mode should only consider active workflows plus the selected
+        # workflow itself. Do not pad with unrelated historical workflows.
+        if selected_session_id:
+            already_active = any(
+                w["workflow_id"] == selected_session_id
+                or any(
+                    s.session_id == selected_session_id
+                    for s in w.get("all_sessions", [])
+                )
+                for w in active_workflows
+            )
+            if already_active:
+                return active_workflows
+
+            specific_wf = SQLiteProcessor.get_workflow_by_id(
+                selected_session_id, db_path
+            )
+            if specific_wf:
+                return active_workflows + [specific_wf]
             return active_workflows
 
         if not allow_fallback:
-            return []
+            return active_workflows
 
-        workflow = SQLiteProcessor.get_most_recent_workflow(db_path)
-        return [workflow] if workflow else []
+        # Combine active and recent workflows, avoiding duplicates (by workflow_id)
+        recent = SQLiteProcessor.get_recent_workflows(db_path, limit=5)
+        seen_ids = {w["workflow_id"] for w in active_workflows}
+        for r in recent:
+            if r["workflow_id"] not in seen_ids:
+                active_workflows.append(r)
+                seen_ids.add(r["workflow_id"])
+
+        return active_workflows[:5]
 
     def _get_latest_sqlite_activity_ts(self, workflow: Dict[str, Any]) -> float:
         """Get latest parent-session activity timestamp for SQLite workflow."""
@@ -834,7 +891,9 @@ class LiveMonitor:
         """
         try:
             active_workflows = self._get_file_active_workflows(
-                base_path, allow_fallback=not bool(selected_session_id)
+                base_path,
+                allow_fallback=not bool(selected_session_id),
+                selected_session_id=selected_session_id,
             )
             if not active_workflows:
                 self.console.print(
@@ -958,7 +1017,9 @@ class LiveMonitor:
                         continue
 
                     active_workflows = self._get_file_active_workflows(
-                        base_path, allow_fallback=not bool(selected_session_id)
+                        base_path,
+                        allow_fallback=not bool(selected_session_id),
+                        selected_session_id=selected_session_id,
                     )
                     descriptors = self._describe_file_workflows(active_workflows)
 
@@ -1504,7 +1565,8 @@ class LiveMonitor:
                 return
 
             active_workflows = self._get_sqlite_active_workflows(
-                allow_fallback=not bool(selected_session_id)
+                allow_fallback=not bool(selected_session_id),
+                selected_session_id=selected_session_id,
             )
             if not active_workflows:
                 self.console.print(
@@ -1690,7 +1752,8 @@ class LiveMonitor:
                         continue
 
                     active_workflows = self._get_sqlite_active_workflows(
-                        allow_fallback=not bool(selected_session_id)
+                        allow_fallback=not bool(selected_session_id),
+                        selected_session_id=selected_session_id,
                     )
                     descriptors = self._describe_sqlite_workflows(active_workflows)
 

--- a/ocmonitor/services/live_monitor.py
+++ b/ocmonitor/services/live_monitor.py
@@ -1,13 +1,14 @@
 """Live monitoring service for OpenCode Monitor."""
 
 import os
+import json
 import select
 import sys
 import time
 from datetime import datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Set, Tuple, cast
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, cast
 
 from rich.console import Console
 from rich.layout import Layout
@@ -99,6 +100,9 @@ class WorkflowWrapper:
 class LiveMonitor:
     """Service for live monitoring of OpenCode sessions."""
 
+    RECENT_TURN_LIMIT = 500
+    RECENT_TURN_PAGE_SIZE = 50
+
     def __init__(
         self,
         pricing_data: Dict[str, ModelPricing],
@@ -129,6 +133,8 @@ class LiveMonitor:
         self._stdin_termios_state: Optional[Any] = None
         self._input_buffer: str = ""
         self._live_status_line: Optional[str] = None
+        self._turn_part_cache: Dict[str, List[Any]] = {}
+        self._turn_user_cache: Dict[str, str] = {}
         if init_from_db:
             self._initialize_active_workflows()
 
@@ -491,12 +497,613 @@ class LiveMonitor:
         """Return optional controls hint shown in dashboard header."""
         if not interactive_switch:
             return None
-        base_hint = (
-            "Workflow switching keys: n=next, p=prev, l=list, 1..9=jump, q=quit."
-        )
+        base_hint = "Workflow keys: n=next, p=prev, l=list, t=turns, 1..9=jump, q=quit."
         if self._live_status_line:
             return f"{base_hint}  Status: {self._live_status_line}"
         return base_hint
+
+    def _get_turn_activity_ts(self, turn: InteractionFile) -> float:
+        """Return a comparable activity timestamp for an interaction turn."""
+        if turn.time_data:
+            if turn.time_data.completed is not None:
+                return turn.time_data.completed / 1000
+            if turn.time_data.created is not None:
+                return turn.time_data.created / 1000
+
+        for raw_key in ("_message_time_updated", "_message_time_created"):
+            raw_timestamp = (turn.raw_data or {}).get(raw_key)
+            if raw_timestamp is None:
+                continue
+            try:
+                return float(raw_timestamp) / 1000
+            except (TypeError, ValueError):
+                continue
+
+        try:
+            return turn.modification_time.timestamp()
+        except (FileNotFoundError, OSError, ValueError):
+            return 0.0
+
+    def _get_workflow_sessions(self, workflow: Any) -> List[SessionData]:
+        """Return all sessions for either file or SQLite workflow shapes."""
+        if isinstance(workflow, dict):
+            return list(workflow.get("all_sessions", []))
+        return list(getattr(workflow, "all_sessions", []) or [])
+
+    def _describe_recent_turns(
+        self, workflow: Any, limit: int = RECENT_TURN_LIMIT
+    ) -> List[Dict[str, Any]]:
+        """Build descriptors for recent non-zero-token turns in a workflow."""
+        turns: List[InteractionFile] = []
+        for session in self._get_workflow_sessions(workflow):
+            turns.extend(session.non_zero_token_files)
+
+        sorted_turns = sorted(turns, key=self._get_turn_activity_ts, reverse=True)[
+            :limit
+        ]
+
+        descriptors: List[Dict[str, Any]] = []
+        for turn in sorted_turns:
+            duration_ms = turn.time_data.duration_ms if turn.time_data else None
+            try:
+                cost = turn.calculate_cost(self.pricing_data)
+            except (TypeError, ValueError, AttributeError):
+                cost = Decimal("0.0")
+
+            descriptors.append(
+                {
+                    "turn": turn,
+                    "session_id": turn.session_id,
+                    "agent": turn.agent or "main",
+                    "model": turn.display_model,
+                    "tokens_input": turn.tokens.input,
+                    "tokens_output": turn.tokens.output,
+                    "tokens_cache_read": turn.tokens.cache_read,
+                    "tokens_cache_write": turn.tokens.cache_write,
+                    "tokens_total": turn.tokens.total,
+                    "duration_ms": duration_ms,
+                    "cost": cost,
+                    "finish_reason": turn.finish_reason or "unknown",
+                    "activity_ts": self._get_turn_activity_ts(turn),
+                }
+            )
+        return descriptors
+
+    def _truncate_turn_text(self, value: Any, max_length: int = 120) -> str:
+        """Return compact single-line text for message/tool previews."""
+        if value is None:
+            return ""
+        if not isinstance(value, str):
+            try:
+                value = json.dumps(value, ensure_ascii=False)
+            except TypeError:
+                value = str(value)
+        text = " ".join(value.split())
+        if len(text) <= max_length:
+            return text
+        return text[: max_length - 3] + "..."
+
+    def _extract_text_from_value(self, value: Any) -> List[str]:
+        """Extract human-readable text snippets from OpenCode message shapes."""
+        snippets: List[str] = []
+        if isinstance(value, str):
+            if value.strip():
+                snippets.append(value)
+            return snippets
+        if isinstance(value, list):
+            for item in value:
+                snippets.extend(self._extract_text_from_value(item))
+            return snippets
+        if not isinstance(value, dict):
+            return snippets
+
+        part_type = value.get("type") or value.get("kind")
+        if part_type in {"text", "reasoning", "user", "assistant"}:
+            for key in ("text", "content", "message", "input", "output"):
+                if isinstance(value.get(key), str):
+                    snippets.append(value[key])
+        elif isinstance(value.get("text"), str):
+            snippets.append(value["text"])
+
+        for key in ("content", "parts", "messages"):
+            child = value.get(key)
+            if child is not value:
+                snippets.extend(self._extract_text_from_value(child))
+        return snippets
+
+    def _extract_turn_message_summary(self, turn: InteractionFile) -> Dict[str, str]:
+        """Extract compact user/assistant text previews from turn raw data."""
+        raw = turn.raw_data or {}
+        role = str(raw.get("role") or "assistant")
+        text_sources: List[Any] = []
+        for key in ("text", "content", "parts", "message", "messages"):
+            if key in raw:
+                text_sources.append(raw[key])
+
+        snippets: List[str] = []
+        for source in text_sources:
+            snippets.extend(self._extract_text_from_value(source))
+
+        assistant_text = ""
+        user_text = ""
+        if role == "user":
+            user_text = self._truncate_turn_text("\n".join(snippets), 220)
+        else:
+            assistant_text = self._truncate_turn_text("\n".join(snippets), 220)
+
+        for key in ("user", "prompt", "request"):
+            if isinstance(raw.get(key), str):
+                user_text = self._truncate_turn_text(raw[key], 220)
+                break
+        for key in ("assistant", "response", "completion"):
+            if isinstance(raw.get(key), str):
+                assistant_text = self._truncate_turn_text(raw[key], 220)
+                break
+
+        sqlite_texts = self._load_sqlite_text_parts_for_turn(turn)
+        if sqlite_texts:
+            assistant_text = assistant_text or self._truncate_turn_text(
+                "\n".join(sqlite_texts), 220
+            )
+
+        sqlite_user_text = self._load_sqlite_user_text_for_turn(turn)
+        if sqlite_user_text:
+            user_text = user_text or self._truncate_turn_text(sqlite_user_text, 220)
+
+        return {
+            "role": role,
+            "user": user_text or "not available in this turn record",
+            "assistant": assistant_text or "not available in this turn record",
+        }
+
+    def _turn_message_id(self, turn: InteractionFile) -> Optional[str]:
+        """Return preserved SQLite message ID for a turn, if available."""
+        message_id = turn.raw_data.get("_message_id") if turn.raw_data else None
+        return str(message_id) if message_id else None
+
+    def _load_sqlite_part_payloads_for_turn(self, turn: InteractionFile) -> List[Any]:
+        """Load raw SQLite part payloads related to a selected message turn."""
+        message_id = self._turn_message_id(turn)
+        if not message_id:
+            return []
+        cache_key = f"{turn.session_id}:{message_id}"
+        if cache_key in self._turn_part_cache:
+            return self._turn_part_cache[cache_key]
+
+        db_path = SQLiteProcessor.find_database_path()
+        if not db_path or not db_path.exists():
+            self._turn_part_cache[cache_key] = []
+            return []
+
+        conn = SQLiteProcessor._get_connection(db_path)
+        try:
+            cursor = conn.execute(
+                """
+                SELECT data
+                FROM part
+                WHERE session_id = ? AND message_id = ?
+                ORDER BY time_created
+                """,
+                (turn.session_id, message_id),
+            )
+            payloads: List[Any] = []
+            for row in cursor:
+                try:
+                    payloads.append(json.loads(row["data"]))
+                except (json.JSONDecodeError, TypeError):
+                    continue
+            self._turn_part_cache[cache_key] = payloads
+            return payloads
+        except Exception:
+            self._turn_part_cache[cache_key] = []
+            return []
+        finally:
+            conn.close()
+
+    def _load_sqlite_text_parts_for_turn(self, turn: InteractionFile) -> List[str]:
+        """Load text-like SQLite part snippets for a selected turn."""
+        snippets: List[str] = []
+        for payload in self._load_sqlite_part_payloads_for_turn(turn):
+            snippets.extend(self._extract_text_from_value(payload))
+        return snippets
+
+    def _load_sqlite_user_text_for_turn(self, turn: InteractionFile) -> str:
+        """Best-effort lookup of the latest user text before a SQLite assistant turn."""
+        message_id = self._turn_message_id(turn)
+        if not message_id:
+            return ""
+        cache_key = f"{turn.session_id}:{message_id}"
+        if cache_key in self._turn_user_cache:
+            return self._turn_user_cache[cache_key]
+
+        db_path = SQLiteProcessor.find_database_path()
+        if not db_path or not db_path.exists():
+            self._turn_user_cache[cache_key] = ""
+            return ""
+
+        raw_time = (turn.raw_data or {}).get("_message_time_created")
+        if raw_time is None:
+            message_time = None
+        else:
+            try:
+                message_time = int(raw_time)
+            except (TypeError, ValueError):
+                message_time = None
+        if message_time is None:
+            self._turn_user_cache[cache_key] = ""
+            return ""
+
+        conn = SQLiteProcessor._get_connection(db_path)
+        try:
+            cursor = conn.execute(
+                """
+                SELECT data
+                FROM message
+                WHERE session_id = ?
+                  AND time_created <= ?
+                  AND json_valid(data) = 1
+                  AND json_extract(data, '$.role') = 'user'
+                ORDER BY time_created DESC
+                LIMIT 1
+                """,
+                (turn.session_id, message_time),
+            )
+            row = cursor.fetchone()
+            if not row:
+                self._turn_user_cache[cache_key] = ""
+                return ""
+            try:
+                payload = json.loads(row["data"])
+            except (json.JSONDecodeError, TypeError):
+                self._turn_user_cache[cache_key] = ""
+                return ""
+            text = self._truncate_turn_text(
+                "\n".join(self._extract_text_from_value(payload)), 220
+            )
+            self._turn_user_cache[cache_key] = text
+            return text
+        except Exception:
+            self._turn_user_cache[cache_key] = ""
+            return ""
+        finally:
+            conn.close()
+
+    def _extract_tool_parts_from_value(self, value: Any) -> List[Dict[str, str]]:
+        """Extract tool-call summaries from nested raw message/part structures."""
+        tools: List[Dict[str, str]] = []
+        if isinstance(value, list):
+            for item in value:
+                tools.extend(self._extract_tool_parts_from_value(item))
+            return tools
+        if not isinstance(value, dict):
+            return tools
+
+        part_type = value.get("type") or value.get("kind")
+        tool_name = value.get("tool") or value.get("name") or value.get("toolName")
+        if (
+            part_type in {"tool", "tool_call", "tool-result", "tool_result"}
+            or tool_name
+        ):
+            state_raw = value.get("state")
+            state = state_raw if isinstance(state_raw, dict) else {}
+            status = value.get("status") or state.get("status") or value.get("state")
+            summary_source = (
+                value.get("text")
+                or value.get("input")
+                or value.get("output")
+                or value.get("error")
+                or state.get("input")
+                or state.get("output")
+                or state.get("error")
+            )
+            tools.append(
+                {
+                    "tool": str(tool_name or "unknown"),
+                    "status": str(status or "unknown"),
+                    "summary": self._truncate_turn_text(summary_source, 100),
+                }
+            )
+
+        for key in ("content", "parts", "messages", "state"):
+            child = value.get(key)
+            if child is not value:
+                tools.extend(self._extract_tool_parts_from_value(child))
+        return tools
+
+    def _load_sqlite_tool_parts_for_turn(
+        self, turn: InteractionFile
+    ) -> List[Dict[str, str]]:
+        """Load SQLite part-table tool rows related to a selected message turn."""
+        tools: List[Dict[str, str]] = []
+        for payload in self._load_sqlite_part_payloads_for_turn(turn):
+            tools.extend(self._extract_tool_parts_from_value(payload))
+        return tools
+
+    def _extract_turn_tool_summary(
+        self, turn: InteractionFile, max_tools: int = 8
+    ) -> List[Dict[str, str]]:
+        """Extract a compact list of tools used by a selected turn."""
+        tools = self._extract_tool_parts_from_value(turn.raw_data or {})
+        sqlite_tools = self._load_sqlite_tool_parts_for_turn(turn)
+        if sqlite_tools:
+            tools.extend(sqlite_tools)
+
+        deduped: List[Dict[str, str]] = []
+        seen = set()
+        for tool in tools:
+            key = (tool["tool"], tool["status"], tool["summary"])
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(tool)
+            if len(deduped) >= max_tools:
+                break
+        return deduped
+
+    def _format_turn_time(self, timestamp: float) -> str:
+        """Format a turn timestamp for compact picker/detail display."""
+        if timestamp <= 0:
+            return "unknown"
+        return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+
+    def _format_turn_duration(self, duration_ms: Optional[int]) -> str:
+        """Format an optional turn duration."""
+        if duration_ms is None:
+            return "unknown"
+        return self.dashboard_ui.format_duration(duration_ms)
+
+    def _print_recent_turn_picker_table(
+        self,
+        descriptors: List[Dict[str, Any]],
+        title: str,
+        page: int = 0,
+        page_size: int = RECENT_TURN_PAGE_SIZE,
+    ) -> None:
+        """Render a picker table for recent workflow turns."""
+        total_pages = max(1, (len(descriptors) + page_size - 1) // page_size)
+        page = max(0, min(page, total_pages - 1))
+        page_start = page * page_size
+        page_descriptors = descriptors[page_start : page_start + page_size]
+
+        table = Table(
+            title=f"{title} (page {page + 1}/{total_pages}, {len(descriptors)} turns)",
+            show_header=True,
+        )
+        table.add_column("#", justify="right", style="metric.value")
+        table.add_column("When", style="table.row.time")
+        table.add_column("Agent", style="dashboard.info")
+        table.add_column("Model", style="table.row.main")
+        table.add_column("Input", justify="right", style="metric.tokens")
+        table.add_column("Output", justify="right", style="metric.tokens")
+        table.add_column("Cache Read", justify="right", style="metric.tokens")
+        table.add_column("Cache Write", justify="right", style="metric.tokens")
+        table.add_column("Turn Tokens", justify="right", style="metric.tokens")
+        table.add_column("Cost", justify="right", style="metric.cost")
+        table.add_column("Duration", justify="right", style="metric.value")
+
+        table.add_column("Preview", style="dim")
+
+        for offset, descriptor in enumerate(page_descriptors, start=1):
+            idx = page_start + offset
+            model = str(descriptor["model"])
+            if len(model) > 34:
+                model = model[:31] + "..."
+
+            turn = cast(InteractionFile, descriptor["turn"])
+            message_summary = self._extract_turn_message_summary(turn)
+            preview_parts = []
+            if message_summary["user"] != "not available in this turn record":
+                preview_parts.append(f"U: {message_summary['user']}")
+            if message_summary["assistant"] != "not available in this turn record":
+                preview_parts.append(f"A: {message_summary['assistant']}")
+            tools = self._extract_turn_tool_summary(turn, max_tools=3)
+            if tools:
+                tool_preview = ", ".join(
+                    f"{tool['tool']}:{tool['status']}" for tool in tools
+                )
+                preview_parts.append(f"Tools: {tool_preview}")
+            preview = " | ".join(preview_parts) or "No message/tool preview available"
+
+            table.add_row(
+                str(idx),
+                self._format_relative_time(descriptor["activity_ts"]),
+                str(descriptor["agent"]),
+                model,
+                f"{descriptor['tokens_input']:,}",
+                f"{descriptor['tokens_output']:,}",
+                f"{descriptor['tokens_cache_read']:,}",
+                f"{descriptor['tokens_cache_write']:,}",
+                f"{descriptor['tokens_total']:,}",
+                self.dashboard_ui._fmt_cost(descriptor["cost"]),
+                self._format_turn_duration(descriptor["duration_ms"]),
+                self._truncate_turn_text(preview, 120),
+            )
+        self.console.print(table)
+
+    def _prompt_for_recent_turn_selection(
+        self,
+        workflow: Any,
+        title: str,
+        limit: int = RECENT_TURN_LIMIT,
+        refresh_workflow: Optional[Callable[[], Any]] = None,
+    ) -> Optional[InteractionFile]:
+        """Prompt user to select a recent turn from the current workflow."""
+        current_workflow = workflow
+        descriptors = self._describe_recent_turns(current_workflow, limit)
+        if not descriptors:
+            self.console.print(
+                "[status.warning]No recent non-zero-token turns available.[/status.warning]"
+            )
+            self._live_status_line = "No recent turns available."
+            return None
+
+        page = 0
+        page_size = self.RECENT_TURN_PAGE_SIZE
+        while True:
+            total_pages = max(1, (len(descriptors) + page_size - 1) // page_size)
+            page = max(0, min(page, total_pages - 1))
+            self._print_recent_turn_picker_table(descriptors, title, page, page_size)
+            choice = (
+                self.console.input(
+                    "[metric.label]Select turn #, n/p page, r refresh, q back to live: [/metric.label]"
+                )
+                .strip()
+                .lower()
+            )
+
+            if not choice or choice in {"q", "quit", "back", "b"}:
+                self._live_status_line = "Turn history cancelled."
+                return None
+            if choice in {"n", "next"}:
+                if page < total_pages - 1:
+                    page += 1
+                else:
+                    self.console.print(
+                        "[status.info]Already on last page.[/status.info]"
+                    )
+                continue
+            if choice in {"p", "prev", "previous"}:
+                if page > 0:
+                    page -= 1
+                else:
+                    self.console.print(
+                        "[status.info]Already on first page.[/status.info]"
+                    )
+                continue
+            if choice in {"r", "refresh"}:
+                if refresh_workflow is not None:
+                    refreshed_workflow = refresh_workflow()
+                    if refreshed_workflow is not None:
+                        current_workflow = refreshed_workflow
+                descriptors = self._describe_recent_turns(current_workflow, limit)
+                if not descriptors:
+                    self.console.print(
+                        "[status.warning]No recent non-zero-token turns available after refresh.[/status.warning]"
+                    )
+                    self._live_status_line = "No recent turns available after refresh."
+                    return None
+                page = 0
+                self._live_status_line = f"Refreshed {len(descriptors)} recent turns."
+                continue
+            if not choice.isdigit():
+                self.console.print(
+                    "[status.warning]Enter a turn number, n/p to page, r to refresh, or q to leave history.[/status.warning]"
+                )
+                continue
+
+            selected_idx = int(choice)
+            if selected_idx < 1 or selected_idx > len(descriptors):
+                self.console.print(
+                    "[status.warning]Selection out of range.[/status.warning]"
+                )
+                continue
+            return cast(InteractionFile, descriptors[selected_idx - 1]["turn"])
+
+    def _print_turn_detail(self, turn: InteractionFile) -> None:
+        """Render detailed stats for one historical turn."""
+        duration_ms = turn.time_data.duration_ms if turn.time_data else None
+        output_rate = "unknown"
+        if duration_ms and duration_ms > 0 and turn.tokens.output > 0:
+            output_rate = f"{turn.tokens.output / (duration_ms / 1000):.1f} tok/s"
+
+        try:
+            cost = turn.calculate_cost(self.pricing_data)
+        except (TypeError, ValueError, AttributeError):
+            cost = Decimal("0.0")
+
+        message_summary = self._extract_turn_message_summary(turn)
+        tool_summary = self._extract_turn_tool_summary(turn)
+
+        detail = Table.grid(padding=(0, 2))
+        detail.add_column(style="metric.label")
+        detail.add_column(style="metric.value")
+        detail.add_row("Role", message_summary["role"])
+        detail.add_row("Session", turn.session_id)
+        detail.add_row("Agent", turn.agent or "main")
+        detail.add_row("Project", turn.project_name)
+        detail.add_row("Model", turn.display_model)
+        detail.add_row(
+            "Activity", self._format_turn_time(self._get_turn_activity_ts(turn))
+        )
+        detail.add_row("Duration", self._format_turn_duration(duration_ms))
+        detail.add_row("Finish", turn.finish_reason or "unknown")
+        detail.add_row("File", turn.file_name)
+        detail.add_row("Input", f"{turn.tokens.input:,}")
+        detail.add_row("Output", f"{turn.tokens.output:,}")
+        detail.add_row("Cache Read", f"{turn.tokens.cache_read:,}")
+        detail.add_row("Cache Write", f"{turn.tokens.cache_write:,}")
+        detail.add_row("Total Tokens", f"{turn.tokens.total:,}")
+        detail.add_row("Cost", self.dashboard_ui._fmt_cost(cost))
+        detail.add_row("Output Rate", output_rate)
+        detail.add_row("User", message_summary["user"])
+        detail.add_row("Assistant", message_summary["assistant"])
+
+        self.console.print(
+            Panel(
+                detail,
+                title="Turn Details",
+                title_align="left",
+                border_style="dashboard.border",
+            )
+        )
+
+        tool_table = Table(title="Turn Tool Calls", show_header=True)
+        tool_table.add_column("#", justify="right", style="metric.value")
+        tool_table.add_column("Tool", style="table.row.main")
+        tool_table.add_column("Status", style="dashboard.info")
+        tool_table.add_column("Preview", style="dim")
+        if tool_summary:
+            for idx, tool in enumerate(tool_summary, start=1):
+                tool_table.add_row(
+                    str(idx), tool["tool"], tool["status"], tool["summary"] or "—"
+                )
+        else:
+            tool_table.add_row("—", "No tool calls found", "—", "—")
+        self.console.print(tool_table)
+
+    def _inspect_recent_turns_during_live(
+        self,
+        live: Live,
+        workflow: Any,
+        title: str,
+        interactive_switch: bool,
+        limit: int = RECENT_TURN_LIMIT,
+        refresh_workflow: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        """Pause live view, show recent-turn picker/details, then resume live view."""
+        raw_mode_was_enabled = self._stdin_fd is not None
+        if raw_mode_was_enabled:
+            self._disable_raw_input_mode()
+
+        try:
+            live.stop()
+            current_workflow = workflow
+
+            def refresh_current_workflow() -> Any:
+                nonlocal current_workflow
+                if refresh_workflow is not None:
+                    refreshed = refresh_workflow()
+                    if refreshed is not None:
+                        current_workflow = refreshed
+                return current_workflow
+
+            while True:
+                if refresh_workflow is not None:
+                    selected_turn = self._prompt_for_recent_turn_selection(
+                        current_workflow, title, limit, refresh_current_workflow
+                    )
+                else:
+                    selected_turn = self._prompt_for_recent_turn_selection(
+                        current_workflow, title, limit
+                    )
+                if not selected_turn:
+                    break
+                self._print_turn_detail(selected_turn)
+                self._live_status_line = f"Viewed turn {selected_turn.file_name}."
+        finally:
+            live.start(refresh=True)
+            if interactive_switch and raw_mode_was_enabled:
+                self._enable_raw_input_mode()
 
     def _handle_live_switch_command(
         self,
@@ -555,7 +1162,7 @@ class LiveMonitor:
             return None, False
 
         self.console.print(
-            "[status.warning]Unknown command. Use next/prev/list/<number>/quit (or n/p/l/q).[/status.warning]"
+            "[status.warning]Unknown command. Use next/prev/list/turns/<number>/quit (or n/p/l/t/q).[/status.warning]"
         )
         self._live_status_line = "Unknown command."
         return None, False
@@ -609,10 +1216,12 @@ class LiveMonitor:
                 return None
 
             # Fast path for ergonomic keybinds.
-            if ch in {"n", "p", "l", "q"} or ch.isdigit():
+            if ch in {"n", "p", "l", "t", "q"} or ch.isdigit():
                 self._input_buffer = ""
                 if ch == "l":
                     return "list"
+                if ch == "t":
+                    return "turns"
                 if ch == "q":
                     return "quit"
                 return ch
@@ -626,6 +1235,9 @@ class LiveMonitor:
                     "previous",
                     "list",
                     "show",
+                    "turn",
+                    "turns",
+                    "history",
                     "quit",
                     "exit",
                 }:
@@ -676,7 +1288,10 @@ class LiveMonitor:
             return
         try:
             import termios
+        except ImportError:
+            return
 
+        try:
             termios.tcsetattr(
                 self._stdin_fd, termios.TCSANOW, self._stdin_termios_state
             )
@@ -944,7 +1559,7 @@ class LiveMonitor:
                 raw_mode_enabled = self._enable_raw_input_mode()
                 self._live_status_line = "Ready."
                 self.console.print(
-                    "[status.info]Interactive switching enabled: press n/p/l/1..9/q[/status.info]"
+                    "[status.info]Interactive controls enabled: press n/p/l/t/1..9/q[/status.info]"
                 )
                 if not raw_mode_enabled:
                     self.console.print(
@@ -986,6 +1601,75 @@ class LiveMonitor:
                                 )
                                 if current_workflow_id != prev_workflow_id:
                                     next_refresh_at = time.time() + refresh_interval
+                                continue
+
+                            if command in {"t", "turn", "turns", "history"}:
+
+                                def refresh_current_turn_workflow() -> Any:
+                                    nonlocal \
+                                        active_workflows, \
+                                        descriptors, \
+                                        current_workflow, \
+                                        current_workflow_id
+                                    active_workflows = self._get_file_active_workflows(
+                                        base_path,
+                                        allow_fallback=not bool(selected_session_id),
+                                        selected_session_id=selected_session_id,
+                                    )
+                                    descriptors = self._describe_file_workflows(
+                                        active_workflows
+                                    )
+                                    if not active_workflows:
+                                        return current_workflow
+
+                                    if selected_session_id:
+                                        refreshed_current = (
+                                            self._resolve_selected_file_workflow(
+                                                active_workflows, selected_session_id
+                                            )
+                                        )
+                                    else:
+                                        refreshed_current = next(
+                                            (
+                                                workflow
+                                                for workflow in active_workflows
+                                                if workflow.workflow_id
+                                                == current_workflow_id
+                                            ),
+                                            None,
+                                        )
+                                    if refreshed_current is None:
+                                        refreshed_current = (
+                                            self._select_most_recent_file_workflow(
+                                                active_workflows
+                                            )
+                                        )
+
+                                    if refreshed_current:
+                                        current_workflow = refreshed_current
+                                        current_workflow_id = (
+                                            current_workflow.workflow_id
+                                        )
+                                        self.prev_tracked |= set(
+                                            s.session_id
+                                            for s in current_workflow.all_sessions
+                                        )
+                                    return current_workflow
+
+                                self._inspect_recent_turns_during_live(
+                                    live,
+                                    current_workflow,
+                                    "Recent Turns",
+                                    interactive_switch,
+                                    refresh_workflow=refresh_current_turn_workflow,
+                                )
+                                live.update(
+                                    self._generate_workflow_dashboard(
+                                        current_workflow,
+                                        self._controls_hint(interactive_switch),
+                                    )
+                                )
+                                next_refresh_at = time.time() + refresh_interval
                                 continue
 
                             (
@@ -1095,6 +1779,9 @@ class LiveMonitor:
         per_model_output_rates = self._calculate_session_output_rates(session)
         per_model_context = self._get_session_context_usage(session)
 
+        # Live output rate (tok/s) over the last 5 minutes for this session
+        burn_rate = self._calculate_output_rate(session)
+
         return self.dashboard_ui.create_dashboard_layout(
             session=session,
             recent_file=recent_file,
@@ -1102,6 +1789,7 @@ class LiveMonitor:
             quota=quota,
             per_model_output_rates=per_model_output_rates,
             per_model_context=per_model_context,
+            burn_rate=burn_rate,
         )
 
     def _calculate_session_output_rates(self, session: SessionData) -> Dict[str, float]:
@@ -1208,6 +1896,9 @@ class LiveMonitor:
         # Calculate per-model context usage
         per_model_context = self._get_per_model_context_usage(workflow)
 
+        # Workflow-wide live output rate (tok/s) for the Output Rate panel
+        burn_rate = self._calculate_workflow_output_rate(workflow.all_sessions)
+
         # Get model pricing for quota
         quota = None
         if recent_file:
@@ -1236,6 +1927,7 @@ class LiveMonitor:
             tool_stats=tool_stats,
             tool_stats_by_model=tool_stats_by_model,
             controls_hint=controls_hint,
+            burn_rate=burn_rate,
         )
 
     def _calculate_per_model_output_rates(
@@ -1364,6 +2056,59 @@ class LiveMonitor:
 
         total_duration_seconds = total_duration_ms / 1000
 
+        if total_duration_seconds > 0:
+            return total_output_tokens / total_duration_seconds
+
+        return 0.0
+
+    def _calculate_workflow_output_rate(
+        self, sessions: List[SessionData]
+    ) -> float:
+        """Calculate p50 output token rate over the last 5 minutes across sessions.
+
+        Pools interactions from every session in a workflow and mirrors the
+        single-session logic in _calculate_output_rate (p50 with a mean
+        fallback) so the live Output Rate panel reflects the whole workflow.
+
+        Args:
+            sessions: All sessions belonging to the workflow
+
+        Returns:
+            P50 output tokens per second over the last 5 minutes, or 0.0
+        """
+        all_files: List[InteractionFile] = []
+        for session in sessions:
+            all_files.extend(session.files)
+
+        if not all_files:
+            return 0.0
+
+        # Use the shared activity-timestamp resolver (time_data first, with a
+        # guarded mtime fallback) so this works for SQLite-sourced interactions
+        # whose file_path is a non-existent placeholder. A raw modification_time
+        # read would raise FileNotFoundError in SQLite mode.
+        cutoff_ts = (datetime.now() - timedelta(minutes=5)).timestamp()
+        recent_interactions = [
+            f for f in all_files if self._get_turn_activity_ts(f) >= cutoff_ts
+        ]
+
+        if not recent_interactions:
+            return 0.0
+
+        rate = compute_p50_output_rate(recent_interactions)
+        if rate > 0:
+            return rate
+
+        total_output_tokens = sum(f.tokens.output for f in recent_interactions)
+        if total_output_tokens == 0:
+            return 0.0
+
+        total_duration_ms = 0
+        for f in recent_interactions:
+            if f.time_data and f.time_data.duration_ms:
+                total_duration_ms += f.time_data.duration_ms
+
+        total_duration_seconds = total_duration_ms / 1000
         if total_duration_seconds > 0:
             return total_output_tokens / total_duration_seconds
 
@@ -1617,7 +2362,7 @@ class LiveMonitor:
                 raw_mode_enabled = self._enable_raw_input_mode()
                 self._live_status_line = "Ready."
                 self.console.print(
-                    "[status.info]Interactive switching enabled: press n/p/l/1..9/q[/status.info]"
+                    "[status.info]Interactive controls enabled: press n/p/l/t/1..9/q[/status.info]"
                 )
                 if not raw_mode_enabled:
                     self.console.print(
@@ -1695,6 +2440,78 @@ class LiveMonitor:
                                             next_refresh_at = (
                                                 time.time() + refresh_interval
                                             )
+                                continue
+
+                            if command in {"t", "turn", "turns", "history"}:
+
+                                def refresh_current_turn_workflow() -> Any:
+                                    nonlocal \
+                                        active_workflows, \
+                                        descriptors, \
+                                        current_workflow, \
+                                        current_workflow_id
+                                    active_workflows = (
+                                        self._get_sqlite_active_workflows(
+                                            allow_fallback=not bool(
+                                                selected_session_id
+                                            ),
+                                            selected_session_id=selected_session_id,
+                                        )
+                                    )
+                                    descriptors = self._describe_sqlite_workflows(
+                                        active_workflows
+                                    )
+                                    if not active_workflows:
+                                        return current_workflow
+
+                                    if selected_session_id:
+                                        refreshed_current = (
+                                            self._resolve_selected_sqlite_workflow(
+                                                active_workflows, selected_session_id
+                                            )
+                                        )
+                                    else:
+                                        refreshed_current = next(
+                                            (
+                                                workflow
+                                                for workflow in active_workflows
+                                                if workflow["workflow_id"]
+                                                == current_workflow_id
+                                            ),
+                                            None,
+                                        )
+                                    if refreshed_current is None:
+                                        refreshed_current = (
+                                            self._select_most_recent_workflow(
+                                                active_workflows
+                                            )
+                                        )
+
+                                    if refreshed_current:
+                                        current_workflow = refreshed_current
+                                        current_workflow_id = current_workflow[
+                                            "workflow_id"
+                                        ]
+                                        self.prev_tracked |= set(
+                                            s.session_id
+                                            for s in current_workflow["all_sessions"]
+                                        )
+                                    return current_workflow
+
+                                self._inspect_recent_turns_during_live(
+                                    live,
+                                    current_workflow,
+                                    "Recent Turns",
+                                    interactive_switch,
+                                    refresh_workflow=refresh_current_turn_workflow,
+                                )
+                                live.update(
+                                    self._generate_sqlite_workflow_dashboard(
+                                        current_workflow,
+                                        self._controls_hint(interactive_switch),
+                                    )
+                                )
+                                next_refresh_at = time.time() + refresh_interval
                                 continue
 
                             new_id, should_quit = self._handle_live_switch_command(
@@ -1897,6 +2714,9 @@ class LiveMonitor:
         # Calculate per-model context usage for SQLite workflow
         per_model_context = self._get_sqlite_per_model_context_usage(workflow)
 
+        # Workflow-wide live output rate (tok/s) for the Output Rate panel
+        burn_rate = self._calculate_workflow_output_rate(workflow["all_sessions"])
+
         # Get model pricing for quota
         quota = None
         if recent_file:
@@ -1929,6 +2749,7 @@ class LiveMonitor:
             tool_stats=tool_stats,
             tool_stats_by_model=tool_stats_by_model,
             controls_hint=controls_hint,
+            burn_rate=burn_rate,
         )
 
     def _calculate_sqlite_per_model_output_rates(

--- a/ocmonitor/ui/dashboard.py
+++ b/ocmonitor/ui/dashboard.py
@@ -98,11 +98,78 @@ class DashboardUI:
             return title[: max_length - 3] + "..."
         return title
 
+    def _describe_activity(
+        self, last_activity_seconds: Optional[float]
+    ) -> Tuple[str, str]:
+        """Map seconds-since-last-activity to a (status_label, style) pair.
+
+        Mirrors the thresholds used by LiveMonitor.get_session_status so the
+        live header and the status API agree on what "active/idle" means.
+        """
+        if last_activity_seconds is None:
+            return "unknown", "dim"
+        if last_activity_seconds < 60:
+            return "active", "status.success"
+        if last_activity_seconds < 300:
+            return "recent", "status.info"
+        if last_activity_seconds < 1800:
+            return "idle", "status.warning"
+        return "inactive", "status.error"
+
+    def _format_activity_indicator(
+        self, last_activity_seconds: Optional[float]
+    ) -> str:
+        """Build a compact colored '● STATUS (Xs ago)' indicator for the header."""
+        label, style = self._describe_activity(last_activity_seconds)
+        if last_activity_seconds is None:
+            ago = "no activity yet"
+        else:
+            secs = int(last_activity_seconds)
+            if secs < 60:
+                ago = f"{secs}s ago"
+            elif secs < 3600:
+                ago = f"{secs // 60}m ago"
+            elif secs < 86400:
+                ago = f"{secs // 3600}h ago"
+            else:
+                ago = f"{secs // 86400}d ago"
+        return f"[{style}]● {label.upper()}[/{style}] [dim]({ago})[/dim]"
+
+    def _recent_activity_seconds(
+        self, recent_file: Optional[Any]
+    ) -> Optional[float]:
+        """Seconds since the most recent interaction, robust to placeholder paths.
+
+        Prefers embedded time_data (which is present for SQLite-sourced
+        interactions whose file_path is a non-existent placeholder) and only
+        falls back to the filesystem mtime for file-based interactions. A raw
+        modification_time read would raise FileNotFoundError in SQLite mode.
+        """
+        if recent_file is None:
+            return None
+
+        activity_ts: Optional[float] = None
+        time_data = getattr(recent_file, "time_data", None)
+        if time_data is not None:
+            if getattr(time_data, "completed", None) is not None:
+                activity_ts = time_data.completed / 1000
+            elif getattr(time_data, "created", None) is not None:
+                activity_ts = time_data.created / 1000
+
+        if activity_ts is None:
+            try:
+                activity_ts = recent_file.modification_time.timestamp()
+            except (FileNotFoundError, OSError, ValueError, AttributeError, TypeError):
+                return None
+
+        return max(0.0, datetime.now().timestamp() - activity_ts)
+
     def create_header(
         self,
         session: SessionData,
         workflow: Optional[SessionWorkflow] = None,
         controls_hint: Optional[str] = None,
+        activity_indicator: Optional[str] = None,
     ) -> Panel:
         """Create header panel with session info."""
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -124,6 +191,11 @@ class DashboardUI:
                 f"[metric.label]Session:[/metric.label] [dashboard.session]{session.display_title}[/dashboard.session]  "
                 f"[metric.label]Updated:[/metric.label] [metric.value]{current_time}[/metric.value]  "
                 f"[metric.label]Interactions:[/metric.label] [metric.value]{session.interaction_count}[/metric.value]"
+            )
+
+        if activity_indicator:
+            header_text += (
+                f"  [metric.label]Activity:[/metric.label] {activity_indicator}"
             )
 
         return Panel(
@@ -1000,6 +1072,7 @@ class DashboardUI:
         tool_stats: Optional[List[ToolUsageStats]] = None,
         tool_stats_by_model: Optional[List[ModelToolUsage]] = None,
         controls_hint: Optional[str] = None,
+        burn_rate: float = 0.0,
     ) -> Layout:
         """Create the complete dashboard layout."""
         layout = Layout()
@@ -1008,10 +1081,16 @@ class DashboardUI:
         per_model_output_rates = per_model_output_rates or {}
         per_model_context = per_model_context or {}
 
+        # Derive a live activity indicator from the most recent interaction.
+        last_activity_seconds = self._recent_activity_seconds(recent_file)
+        activity_indicator = self._format_activity_indicator(last_activity_seconds)
+
         # Use workflow data if available, otherwise use session data
         if workflow and workflow.has_sub_agents:
             # Create panels using workflow totals
-            header = self.create_header(session, workflow)
+            header = self.create_header(
+                session, workflow, activity_indicator=activity_indicator
+            )
             token_panel = self.create_workflow_token_panel(workflow, recent_file)
             status_panel = self.create_workflow_status_panel(
                 workflow, pricing_data, quota
@@ -1021,7 +1100,9 @@ class DashboardUI:
             )
         else:
             # Create panels using single session data
-            header = self.create_header(session)
+            header = self.create_header(
+                session, activity_indicator=activity_indicator
+            )
             token_panel = self.create_token_panel(session, recent_file)
             status_panel = self.create_status_panel(session, pricing_data, quota)
             model_panel = self.create_model_panel(
@@ -1029,6 +1110,7 @@ class DashboardUI:
             )
 
         recent_file_panel = self.create_recent_file_panel(recent_file)
+        burn_rate_panel = self.create_burn_rate_panel(burn_rate)
 
         # Determine which tool display to use based on model count
         by_model = tool_stats_by_model or []
@@ -1106,11 +1188,13 @@ class DashboardUI:
                 Layout(name="models_tools", minimum_size=4),  # Model + Tool breakdown
             )
 
-        # Metrics section: 3-column layout (Tokens 50% | Status 25% | Recent 25%)
+        # Metrics section: 4-column layout
+        # (Tokens 40% | Status 20% | Output Rate 20% | Recent 20%)
         layout["metrics"].split_row(
-            Layout(token_panel, ratio=2),  # 50% - token data (most content)
-            Layout(status_panel, ratio=1),  # 25% - cost + time combined
-            Layout(recent_file_panel, ratio=1),  # 25% - recent file info
+            Layout(token_panel, ratio=2),  # token data (most content)
+            Layout(status_panel, ratio=1),  # cost + time combined
+            Layout(burn_rate_panel, ratio=1),  # live output tok/s
+            Layout(recent_file_panel, ratio=1),  # recent file info
         )
 
         # Models + Tools section: Full width to tools when using grid (model info embedded in tool panels)

--- a/ocmonitor/ui/dashboard.py
+++ b/ocmonitor/ui/dashboard.py
@@ -11,7 +11,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from ..models.session import SessionData
+from ..models.session import SessionData, TokenUsage
 from ..models.tool_usage import ToolUsageStats, ModelToolUsage
 from ..models.workflow import SessionWorkflow
 from ..utils.formatting import ColorFormatter
@@ -36,6 +36,33 @@ class DashboardUI:
         if self.currency_converter:
             return self.currency_converter.format(amount)
         return f"${amount:.2f}"
+
+    def _fmt_compact_count(self, value: float) -> str:
+        """Format a count compactly for dense dashboard rows."""
+        abs_value = abs(value)
+        if abs_value >= 1_000_000:
+            formatted = f"{value / 1_000_000:.1f}M"
+        elif abs_value >= 1_000:
+            formatted = f"{value / 1_000:.1f}k"
+        else:
+            formatted = f"{value:.0f}"
+        return formatted.replace(".0M", "M").replace(".0k", "k")
+
+    def _format_tool_token_suffix(self, stat: ToolUsageStats) -> str:
+        """Format compact attributed per-tool token details for a tool row."""
+        if stat.total_tokens <= 0:
+            return ""
+
+        avg_tokens = stat.total_tokens / stat.total_calls if stat.total_calls else 0.0
+
+        return (
+            f"  [metric.tokens]{self._fmt_compact_count(stat.total_tokens)}[/metric.tokens] tok"
+            f" avg [metric.value]{self._fmt_compact_count(avg_tokens)}[/metric.value]/call"
+            f" · I [metric.value]{self._fmt_compact_count(stat.input_tokens)}[/metric.value]"
+            f" O [metric.value]{self._fmt_compact_count(stat.output_tokens)}[/metric.value]"
+            f" CR [metric.value]{self._fmt_compact_count(stat.cache_read_tokens)}[/metric.value]"
+            f" CW [metric.value]{self._fmt_compact_count(stat.cache_write_tokens)}[/metric.value]"
+        )
 
     def create_header(
         self,
@@ -176,20 +203,24 @@ class DashboardUI:
         model_lines = []
         for model, stats in model_breakdown.items():
             model_name = model[:35] + "..." if len(model) > 38 else model
-            
+
             # Get context usage for this model
             context_info = per_model_context.get(model, {})
             context_pct = context_info.get("usage_percentage", 0.0)
             context_bar = self.create_compact_progress_bar(context_pct, 8)
-            
+
             # Get output rate for this model
             output_rate = per_model_output_rates.get(model, 0.0)
             rate_str = f" - {output_rate:.1f} tok/s" if output_rate > 0 else ""
-            
+
             model_lines.append(
-                f"[metric.label]{model_name}[/metric.label]  -  "
-                f"[metric.value]{stats['tokens'].total:,}[/metric.value] [metric.tokens]tok[/metric.tokens]  "
-                f"[metric.cost]{self._fmt_cost(stats['cost'])}[/metric.cost]  -  "
+                f"[metric.label]{model_name}[/metric.label]\n"
+                f"  └─ Tokens: [metric.value]{stats['tokens'].total:,}[/metric.value] tok "
+                f"(In: [metric.value]{stats['tokens'].input:,}[/metric.value] | "
+                f"Out: [metric.value]{stats['tokens'].output:,}[/metric.value] | "
+                f"CW: [metric.value]{stats['tokens'].cache_write:,}[/metric.value] | "
+                f"CR: [metric.value]{stats['tokens'].cache_read:,}[/metric.value])\n"
+                f"  └─ Cost: [metric.cost]{self._fmt_cost(stats['cost'])}[/metric.cost]  -  "
                 f"context {context_bar}{rate_str}"
             )
 
@@ -349,8 +380,7 @@ class DashboardUI:
             )
         else:
             time_section = (
-                f"[dashboard.header]Time[/dashboard.header]\n"
-                f"[dim]No timing data[/dim]"
+                f"[dashboard.header]Time[/dashboard.header]\n[dim]No timing data[/dim]"
             )
 
         status_text = (
@@ -412,8 +442,7 @@ class DashboardUI:
             )
         else:
             time_section = (
-                f"[dashboard.header]Time[/dashboard.header]\n"
-                f"[dim]No timing data[/dim]"
+                f"[dashboard.header]Time[/dashboard.header]\n[dim]No timing data[/dim]"
             )
 
         status_text = (
@@ -493,6 +522,7 @@ class DashboardUI:
                 f"[metric.label]{tool_name:<12}[/metric.label] "
                 f"[metric.value]{stat.total_calls:>4}[/metric.value] "
                 f"[{color}]{bar}[/{color}]"
+                f"{self._format_tool_token_suffix(stat)}"
             )
 
         tool_text = "\n".join(lines)
@@ -525,8 +555,12 @@ class DashboardUI:
         model_tool_usage: ModelToolUsage,
         max_tools: int = 15,
         model_tokens: Optional[int] = None,
+        model_token_details: Optional[Dict[str, int]] = None,
+        model_interactions: Optional[int] = None,
         model_cost: Optional[Decimal] = None,
         context_pct: Optional[float] = None,
+        context_size: Optional[int] = None,
+        context_window: Optional[int] = None,
         output_rate: Optional[float] = None,
     ) -> Panel:
         """Create a panel showing tool usage for a single model.
@@ -535,8 +569,12 @@ class DashboardUI:
             model_tool_usage: ModelToolUsage containing model name and tool stats
             max_tools: Maximum number of tools to display
             model_tokens: Optional token count for this model to display in header
+            model_token_details: Optional per-token-kind details for this model
+            model_interactions: Optional interaction/message count for this model
             model_cost: Optional cost for this model to display in header
             context_pct: Optional context usage percentage for this model
+            context_size: Optional recent context size for this model
+            context_window: Optional context window for this model
             output_rate: Optional output rate (tok/sec) for this model
 
         Returns:
@@ -559,22 +597,56 @@ class DashboardUI:
         lines = []
 
         if model_tokens is not None:
-            cost_str = f" [metric.cost]{self._fmt_cost(model_cost)}[/metric.cost]" if model_cost is not None else ""
-            
-            # Add context and output rate info
-            extra_info = []
+            details = model_token_details or {"total": model_tokens}
+            input_tokens = details.get("input", 0)
+            output_tokens = details.get("output", 0)
+            cache_read = details.get("cache_read", 0)
+            cache_write = details.get("cache_write", 0)
+            cache_total = cache_read + cache_write
+
+            lines.append(
+                f"[metric.label]Tokens:[/metric.label] "
+                f"[metric.value]{model_tokens:,}[/metric.value] [metric.tokens]total[/metric.tokens]"
+            )
+            if model_interactions is not None:
+                lines.append(
+                    f"  Interactions [metric.value]{model_interactions:,}[/metric.value]"
+                )
+            lines.append(
+                f"  Input [metric.value]{input_tokens:,}[/metric.value]  "
+                f"Output [metric.value]{output_tokens:,}[/metric.value]"
+            )
+            lines.append(
+                f"  Cache Read [metric.value]{cache_read:,}[/metric.value]  "
+                f"Write [metric.value]{cache_write:,}[/metric.value]"
+            )
+            lines.append(f"  Cache Total [metric.value]{cache_total:,}[/metric.value]")
+
+            if model_cost is not None or (output_rate is not None and output_rate > 0):
+                perf_parts = []
+                if model_cost is not None:
+                    perf_parts.append(
+                        f"Cost [metric.cost]{self._fmt_cost(model_cost)}[/metric.cost]"
+                    )
+                if output_rate is not None and output_rate > 0:
+                    perf_parts.append(
+                        f"Rate [metric.value]{output_rate:.1f}[/metric.value] tok/s"
+                    )
+                lines.append("  " + "  ".join(perf_parts))
+
             if context_pct is not None:
                 context_bar = self.create_compact_progress_bar(context_pct, 8)
-                extra_info.append(f"context {context_bar}")
-            if output_rate is not None and output_rate > 0:
-                extra_info.append(f"{output_rate:.1f} tok/s")
-            
-            extra_str = "  " + "  ".join(extra_info) if extra_info else ""
-            
+                if context_size is not None and context_window is not None:
+                    lines.append(
+                        f"  Ctx [metric.value]{context_size:,}[/metric.value]/"
+                        f"[metric.value]{context_window:,}[/metric.value] {context_bar}"
+                    )
+                else:
+                    lines.append(f"  Ctx {context_bar}")
+
             lines.append(
-                f"[metric.value]{model_tokens:,}[/metric.value] [metric.tokens]tokens[/metric.tokens]{cost_str}{extra_str}"
+                "[dashboard.border]────────────────────────[/dashboard.border]"
             )
-            lines.append("[dashboard.border]────────────────────────[/dashboard.border]")
 
         for stat in tool_stats:
             tool_name = stat.tool_name
@@ -589,6 +661,7 @@ class DashboardUI:
                 f"[metric.label]{tool_name:<12}[/metric.label] "
                 f"[metric.value]{stat.total_calls:>3}[/metric.value] "
                 f"[{color}]{bar}[/{color}]"
+                f"{self._format_tool_token_suffix(stat)}"
             )
 
         tool_text = "\n".join(lines)
@@ -633,20 +706,144 @@ class DashboardUI:
         per_model_output_rates = per_model_output_rates or {}
         per_model_context = per_model_context or {}
 
+        def _extract_token_details(tokens_value: Any) -> Dict[str, int]:
+            """Extract token kind totals from TokenUsage-like, dict, or numeric values."""
+
+            def _to_int(value: Any) -> int:
+                try:
+                    return int(value or 0)
+                except (TypeError, ValueError):
+                    return 0
+
+            if hasattr(tokens_value, "total"):
+                return {
+                    "input": _to_int(getattr(tokens_value, "input", 0)),
+                    "output": _to_int(getattr(tokens_value, "output", 0)),
+                    "cache_read": _to_int(getattr(tokens_value, "cache_read", 0)),
+                    "cache_write": _to_int(getattr(tokens_value, "cache_write", 0)),
+                    "total": _to_int(getattr(tokens_value, "total", 0)),
+                }
+
+            if isinstance(tokens_value, dict):
+                input_tokens = _to_int(tokens_value.get("input", 0))
+                output_tokens = _to_int(tokens_value.get("output", 0))
+                cache_read = _to_int(tokens_value.get("cache_read", 0))
+                cache_write = _to_int(tokens_value.get("cache_write", 0))
+                total = _to_int(
+                    tokens_value.get(
+                        "total", input_tokens + output_tokens + cache_read + cache_write
+                    )
+                )
+                return {
+                    "input": input_tokens,
+                    "output": output_tokens,
+                    "cache_read": cache_read,
+                    "cache_write": cache_write,
+                    "total": total,
+                }
+
+            total = _to_int(tokens_value)
+
+            return {
+                "input": 0,
+                "output": 0,
+                "cache_read": 0,
+                "cache_write": 0,
+                "total": total,
+            }
+
+        def _to_decimal(cost_value: Any) -> Decimal:
+            """Convert a cost value to Decimal safely."""
+            if isinstance(cost_value, Decimal):
+                return cost_value
+
+            try:
+                return Decimal(str(cost_value))
+            except (ArithmeticError, ValueError, TypeError):
+                return Decimal("0.0")
+
+        # Build bare-model fallbacks so SQLite tool rows (bare model IDs) can
+        # still match workflow model breakdown keys that are provider-prefixed.
+        model_breakdown_by_bare: Dict[str, Dict[str, Any]] = {}
+        for key, stats in model_breakdown.items():
+            if not isinstance(stats, dict):
+                continue
+
+            bare_model = key.split("/", 1)[-1]
+            bucket = model_breakdown_by_bare.setdefault(
+                bare_model,
+                {
+                    "token_details": {
+                        "input": 0,
+                        "output": 0,
+                        "cache_read": 0,
+                        "cache_write": 0,
+                        "total": 0,
+                    },
+                    "files": 0,
+                    "cost": Decimal("0.0"),
+                },
+            )
+            details = _extract_token_details(stats.get("tokens"))
+            for token_key, token_value in details.items():
+                bucket["token_details"][token_key] += token_value
+            bucket["files"] += int(stats.get("files", 0) or 0)
+            bucket["cost"] += _to_decimal(stats.get("cost", Decimal("0.0")))
+
+        per_model_context_by_bare: Dict[str, Dict[str, Any]] = {}
+        for key, context_info in per_model_context.items():
+            if isinstance(context_info, dict):
+                per_model_context_by_bare.setdefault(
+                    key.split("/", 1)[-1], context_info
+                )
+
+        per_model_output_rates_by_bare: Dict[str, float] = {}
+        for key, rate in per_model_output_rates.items():
+            per_model_output_rates_by_bare.setdefault(key.split("/", 1)[-1], rate)
+
         def get_model_info(model_name: str):
             """Return tokens, cost, context usage, and output rate for a model."""
-            if model_name in model_breakdown:
-                stats = model_breakdown[model_name]
-                tokens = stats.get("tokens", {}).total if hasattr(stats.get("tokens", {}), "total") else stats.get("tokens", 0)
-                cost = stats.get("cost")
+            bare_model = model_name.split("/", 1)[-1]
+
+            stats = model_breakdown.get(model_name)
+            if isinstance(stats, dict):
+                token_details = _extract_token_details(stats.get("tokens"))
+                tokens = token_details["total"]
+                interactions = int(stats.get("files", 0) or 0)
+                cost = _to_decimal(stats.get("cost", Decimal("0.0")))
             else:
-                tokens, cost = None, None
-            
-            context_info = per_model_context.get(model_name, {})
-            context_pct = context_info.get("usage_percentage")
-            output_rate = per_model_output_rates.get(model_name, 0.0)
-            
-            return tokens, cost, context_pct, output_rate
+                aggregate = model_breakdown_by_bare.get(bare_model)
+                if aggregate:
+                    token_details = aggregate["token_details"]
+                    tokens = token_details["total"]
+                    interactions = int(aggregate.get("files", 0) or 0)
+                    cost = aggregate["cost"]
+                else:
+                    tokens, token_details, interactions, cost = None, None, None, None
+
+            context_info = per_model_context.get(model_name)
+            if not isinstance(context_info, dict):
+                context_info = per_model_context_by_bare.get(bare_model, {})
+            context_pct = context_info.get("usage_percentage") if context_info else None
+            context_size = context_info.get("context_size") if context_info else None
+            context_window = (
+                context_info.get("context_window") if context_info else None
+            )
+
+            output_rate = per_model_output_rates.get(model_name)
+            if output_rate is None:
+                output_rate = per_model_output_rates_by_bare.get(bare_model, 0.0)
+
+            return (
+                tokens,
+                token_details,
+                interactions,
+                cost,
+                context_pct,
+                context_size,
+                context_window,
+                output_rate,
+            )
 
         left_models = []
         right_models = []
@@ -658,19 +855,55 @@ class DashboardUI:
 
         left_panels = []
         for model_usage in left_models:
-            model_tokens, model_cost, context_pct, output_rate = get_model_info(model_usage.model_name)
-            left_panels.append(self.create_model_tool_panel(
-                model_usage, model_tokens=model_tokens, model_cost=model_cost,
-                context_pct=context_pct, output_rate=output_rate
-            ))
+            (
+                model_tokens,
+                model_token_details,
+                model_interactions,
+                model_cost,
+                context_pct,
+                context_size,
+                context_window,
+                output_rate,
+            ) = get_model_info(model_usage.model_name)
+            left_panels.append(
+                self.create_model_tool_panel(
+                    model_usage,
+                    model_tokens=model_tokens,
+                    model_token_details=model_token_details,
+                    model_interactions=model_interactions,
+                    model_cost=model_cost,
+                    context_pct=context_pct,
+                    context_size=context_size,
+                    context_window=context_window,
+                    output_rate=output_rate,
+                )
+            )
 
         right_panels = []
         for model_usage in right_models:
-            model_tokens, model_cost, context_pct, output_rate = get_model_info(model_usage.model_name)
-            right_panels.append(self.create_model_tool_panel(
-                model_usage, model_tokens=model_tokens, model_cost=model_cost,
-                context_pct=context_pct, output_rate=output_rate
-            ))
+            (
+                model_tokens,
+                model_token_details,
+                model_interactions,
+                model_cost,
+                context_pct,
+                context_size,
+                context_window,
+                output_rate,
+            ) = get_model_info(model_usage.model_name)
+            right_panels.append(
+                self.create_model_tool_panel(
+                    model_usage,
+                    model_tokens=model_tokens,
+                    model_token_details=model_token_details,
+                    model_interactions=model_interactions,
+                    model_cost=model_cost,
+                    context_pct=context_pct,
+                    context_size=context_size,
+                    context_window=context_window,
+                    output_rate=output_rate,
+                )
+            )
 
         left_column = Layout()
         if left_panels:
@@ -722,7 +955,9 @@ class DashboardUI:
             # Create panels using workflow totals
             header = self.create_header(session, workflow)
             token_panel = self.create_workflow_token_panel(workflow, recent_file)
-            status_panel = self.create_workflow_status_panel(workflow, pricing_data, quota)
+            status_panel = self.create_workflow_status_panel(
+                workflow, pricing_data, quota
+            )
             model_panel = self.create_workflow_model_panel(
                 workflow, pricing_data, per_model_output_rates, per_model_context
             )
@@ -746,11 +981,27 @@ class DashboardUI:
         if use_grid:
             if workflow and workflow.has_sub_agents:
                 from collections import defaultdict
-                model_breakdown = defaultdict(lambda: {"tokens": 0, "cost": Decimal("0.0")})
+
+                model_breakdown = defaultdict(
+                    lambda: {
+                        "tokens": TokenUsage(),
+                        "files": 0,
+                        "cost": Decimal("0.0"),
+                    }
+                )
                 for sess in workflow.all_sessions:
                     sess_breakdown = sess.get_model_breakdown(pricing_data)
                     for model, stats in sess_breakdown.items():
-                        model_breakdown[model]["tokens"] += stats["tokens"].total
+                        model_tokens = stats["tokens"]
+                        model_breakdown[model]["tokens"].input += model_tokens.input
+                        model_breakdown[model]["tokens"].output += model_tokens.output
+                        model_breakdown[model][
+                            "tokens"
+                        ].cache_read += model_tokens.cache_read
+                        model_breakdown[model][
+                            "tokens"
+                        ].cache_write += model_tokens.cache_write
+                        model_breakdown[model]["files"] += stats.get("files", 0)
                         model_breakdown[model]["cost"] += stats["cost"]
                 model_breakdown = dict(model_breakdown)
             else:
@@ -782,14 +1033,18 @@ class DashboardUI:
             controls_panel = self.create_controls_panel(controls_hint)
             layout.split_column(
                 Layout(header, size=3),  # Compact header
-                Layout(name="metrics", size=12),  # Tokens + Status + Recent (single row)
+                Layout(
+                    name="metrics", size=12
+                ),  # Tokens + Status + Recent (single row)
                 Layout(name="models_tools", minimum_size=4),  # Model + Tool breakdown
                 Layout(controls_panel, size=3),  # Persistent keybind visibility
             )
         else:
             layout.split_column(
                 Layout(header, size=3),  # Compact header
-                Layout(name="metrics", size=12),  # Tokens + Status + Recent (single row)
+                Layout(
+                    name="metrics", size=12
+                ),  # Tokens + Status + Recent (single row)
                 Layout(name="models_tools", minimum_size=4),  # Model + Tool breakdown
             )
 
@@ -943,13 +1198,18 @@ class DashboardUI:
 
         # Aggregate model stats across all sessions
         model_data: Dict[str, Dict[str, Any]] = defaultdict(
-            lambda: {"tokens": 0, "cost": Decimal("0.0")}
+            lambda: {"tokens": TokenUsage(), "files": 0, "cost": Decimal("0.0")}
         )
 
         for session in workflow.all_sessions:
             model_breakdown = session.get_model_breakdown(pricing_data)
             for model, stats in model_breakdown.items():
-                model_data[model]["tokens"] += stats["tokens"].total
+                model_tokens = stats["tokens"]
+                model_data[model]["tokens"].input += model_tokens.input
+                model_data[model]["tokens"].output += model_tokens.output
+                model_data[model]["tokens"].cache_read += model_tokens.cache_read
+                model_data[model]["tokens"].cache_write += model_tokens.cache_write
+                model_data[model]["files"] += stats.get("files", 0)
                 model_data[model]["cost"] += stats["cost"]
 
         if not model_data:
@@ -964,21 +1224,41 @@ class DashboardUI:
             model_data.items(), key=lambda x: x[1]["cost"], reverse=True
         ):
             model_name = model[:35] + "..." if len(model) > 38 else model
-            
+            bare_model = model.split("/", 1)[-1]
+            token_usage = stats["tokens"]
+
             # Get context usage for this model
-            context_info = per_model_context.get(model, {})
+            context_info = per_model_context.get(model) or per_model_context.get(
+                bare_model, {}
+            )
             context_pct = context_info.get("usage_percentage", 0.0)
             context_bar = self.create_compact_progress_bar(context_pct, 8)
-            
+            context_size = context_info.get("context_size")
+            context_window = context_info.get("context_window")
+            if context_size is not None and context_window is not None:
+                context_str = (
+                    f"context [metric.value]{context_size:,}[/metric.value]/"
+                    f"[metric.value]{context_window:,}[/metric.value] {context_bar}"
+                )
+            else:
+                context_str = f"context {context_bar}"
+
             # Get output rate for this model
-            output_rate = per_model_output_rates.get(model, 0.0)
+            output_rate = per_model_output_rates.get(
+                model, per_model_output_rates.get(bare_model, 0.0)
+            )
             rate_str = f" - {output_rate:.1f} tok/s" if output_rate > 0 else ""
-            
+
             model_lines.append(
-                f"[metric.label]{model_name}[/metric.label]  -  "
-                f"[metric.value]{stats['tokens']:,}[/metric.value] [metric.tokens]tok[/metric.tokens]  "
-                f"[metric.cost]{self._fmt_cost(stats['cost'])}[/metric.cost]  -  "
-                f"context {context_bar}{rate_str}"
+                f"[metric.label]{model_name}[/metric.label]\n"
+                f"  └─ Tokens: [metric.value]{token_usage.total:,}[/metric.value] tok "
+                f"([metric.label]In:[/metric.label] [metric.value]{token_usage.input:,}[/metric.value] | "
+                f"[metric.label]Out:[/metric.label] [metric.value]{token_usage.output:,}[/metric.value] | "
+                f"[metric.label]CW:[/metric.label] [metric.value]{token_usage.cache_write:,}[/metric.value] | "
+                f"[metric.label]CR:[/metric.label] [metric.value]{token_usage.cache_read:,}[/metric.value])\n"
+                f"  └─ Interactions: [metric.value]{stats['files']:,}[/metric.value]  -  "
+                f"Cost: [metric.cost]{self._fmt_cost(stats['cost'])}[/metric.cost]  -  "
+                f"{context_str}{rate_str}"
             )
 
         model_text = "\n".join(model_lines)

--- a/ocmonitor/ui/dashboard.py
+++ b/ocmonitor/ui/dashboard.py
@@ -3,7 +3,7 @@
 import os
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from rich.console import Console
 from rich.layout import Layout
@@ -63,6 +63,40 @@ class DashboardUI:
             f" CR [metric.value]{self._fmt_compact_count(stat.cache_read_tokens)}[/metric.value]"
             f" CW [metric.value]{self._fmt_compact_count(stat.cache_write_tokens)}[/metric.value]"
         )
+
+    def _split_agent_model_key(self, key: str) -> Tuple[Optional[str], str]:
+        """Split an optional agent/model grouping key into display parts."""
+        if "::" in key:
+            agent, model = key.split("::", 1)
+            return agent or None, model
+        return None, key
+
+    def _agent_model_lookup_key(
+        self, agent_name: Optional[str], model_name: str
+    ) -> str:
+        """Build the canonical dashboard lookup key for an agent/model pair."""
+        return SessionData.agent_model_key(agent_name or "main", model_name)
+
+    def _bare_lookup_key(self, key: str) -> str:
+        """Return a provider-stripped lookup key while preserving agent scope."""
+        agent, model = self._split_agent_model_key(key)
+        bare_model = model.split("/", 1)[-1]
+        return self._agent_model_lookup_key(agent, bare_model)
+
+    def _format_agent_model_title(
+        self,
+        agent_name: Optional[str],
+        model_name: str,
+        include_agent: bool = True,
+        max_length: int = 60,
+    ) -> str:
+        """Format a compact title for an agent/model dashboard pane."""
+        title = (
+            f"{agent_name or 'main'} / {model_name}" if include_agent else model_name
+        )
+        if len(title) > max_length:
+            return title[: max_length - 3] + "..."
+        return title
 
     def create_header(
         self,
@@ -580,9 +614,12 @@ class DashboardUI:
         Returns:
             Panel with tool usage information for this model
         """
-        model_name = model_tool_usage.model_name
-        if len(model_name) > 35:
-            model_name = model_name[:32] + "..."
+        model_name = self._format_agent_model_title(
+            model_tool_usage.agent_name,
+            model_tool_usage.model_name,
+            include_agent=model_tool_usage.agent_name is not None,
+            max_length=35,
+        )
 
         tool_stats = model_tool_usage.tool_stats[:max_tools]
 
@@ -763,13 +800,14 @@ class DashboardUI:
                 return Decimal("0.0")
 
         # Build bare-model fallbacks so SQLite tool rows (bare model IDs) can
-        # still match workflow model breakdown keys that are provider-prefixed.
+        # still match workflow model breakdown keys that are provider-prefixed,
+        # while preserving any agent scope in composite agent::model keys.
         model_breakdown_by_bare: Dict[str, Dict[str, Any]] = {}
         for key, stats in model_breakdown.items():
             if not isinstance(stats, dict):
                 continue
 
-            bare_model = key.split("/", 1)[-1]
+            bare_model = self._bare_lookup_key(key)
             bucket = model_breakdown_by_bare.setdefault(
                 bare_model,
                 {
@@ -794,25 +832,33 @@ class DashboardUI:
         for key, context_info in per_model_context.items():
             if isinstance(context_info, dict):
                 per_model_context_by_bare.setdefault(
-                    key.split("/", 1)[-1], context_info
+                    self._bare_lookup_key(key), context_info
                 )
 
         per_model_output_rates_by_bare: Dict[str, float] = {}
         for key, rate in per_model_output_rates.items():
-            per_model_output_rates_by_bare.setdefault(key.split("/", 1)[-1], rate)
+            per_model_output_rates_by_bare.setdefault(self._bare_lookup_key(key), rate)
 
-        def get_model_info(model_name: str):
+        def get_model_info(model_usage: ModelToolUsage):
             """Return tokens, cost, context usage, and output rate for a model."""
-            bare_model = model_name.split("/", 1)[-1]
+            model_name = model_usage.model_name
+            direct_key = self._agent_model_lookup_key(
+                model_usage.agent_name, model_name
+            )
+            bare_key = self._bare_lookup_key(direct_key)
 
-            stats = model_breakdown.get(model_name)
+            stats = model_breakdown.get(direct_key) or model_breakdown.get(model_name)
             if isinstance(stats, dict):
                 token_details = _extract_token_details(stats.get("tokens"))
                 tokens = token_details["total"]
                 interactions = int(stats.get("files", 0) or 0)
                 cost = _to_decimal(stats.get("cost", Decimal("0.0")))
             else:
-                aggregate = model_breakdown_by_bare.get(bare_model)
+                aggregate = model_breakdown_by_bare.get(bare_key)
+                if not aggregate and model_usage.agent_name is None:
+                    aggregate = model_breakdown_by_bare.get(
+                        model_name.split("/", 1)[-1]
+                    )
                 if aggregate:
                     token_details = aggregate["token_details"]
                     tokens = token_details["total"]
@@ -821,18 +867,30 @@ class DashboardUI:
                 else:
                     tokens, token_details, interactions, cost = None, None, None, None
 
-            context_info = per_model_context.get(model_name)
+            context_info = per_model_context.get(direct_key) or per_model_context.get(
+                model_name
+            )
             if not isinstance(context_info, dict):
-                context_info = per_model_context_by_bare.get(bare_model, {})
+                context_info = per_model_context_by_bare.get(bare_key, {})
+                if not context_info and model_usage.agent_name is None:
+                    context_info = per_model_context_by_bare.get(
+                        model_name.split("/", 1)[-1], {}
+                    )
             context_pct = context_info.get("usage_percentage") if context_info else None
             context_size = context_info.get("context_size") if context_info else None
             context_window = (
                 context_info.get("context_window") if context_info else None
             )
 
-            output_rate = per_model_output_rates.get(model_name)
+            output_rate = per_model_output_rates.get(direct_key)
             if output_rate is None:
-                output_rate = per_model_output_rates_by_bare.get(bare_model, 0.0)
+                output_rate = per_model_output_rates.get(model_name)
+            if output_rate is None:
+                output_rate = per_model_output_rates_by_bare.get(bare_key, 0.0)
+            if output_rate is None and model_usage.agent_name is None:
+                output_rate = per_model_output_rates_by_bare.get(
+                    model_name.split("/", 1)[-1], 0.0
+                )
 
             return (
                 tokens,
@@ -864,7 +922,7 @@ class DashboardUI:
                 context_size,
                 context_window,
                 output_rate,
-            ) = get_model_info(model_usage.model_name)
+            ) = get_model_info(model_usage)
             left_panels.append(
                 self.create_model_tool_panel(
                     model_usage,
@@ -890,7 +948,7 @@ class DashboardUI:
                 context_size,
                 context_window,
                 output_rate,
-            ) = get_model_info(model_usage.model_name)
+            ) = get_model_info(model_usage)
             right_panels.append(
                 self.create_model_tool_panel(
                     model_usage,
@@ -990,7 +1048,7 @@ class DashboardUI:
                     }
                 )
                 for sess in workflow.all_sessions:
-                    sess_breakdown = sess.get_model_breakdown(pricing_data)
+                    sess_breakdown = sess.get_agent_model_breakdown(pricing_data)
                     for model, stats in sess_breakdown.items():
                         model_tokens = stats["tokens"]
                         model_breakdown[model]["tokens"].input += model_tokens.input
@@ -1202,7 +1260,7 @@ class DashboardUI:
         )
 
         for session in workflow.all_sessions:
-            model_breakdown = session.get_model_breakdown(pricing_data)
+            model_breakdown = session.get_agent_model_breakdown(pricing_data)
             for model, stats in model_breakdown.items():
                 model_tokens = stats["tokens"]
                 model_data[model]["tokens"].input += model_tokens.input
@@ -1223,8 +1281,14 @@ class DashboardUI:
         for model, stats in sorted(
             model_data.items(), key=lambda x: x[1]["cost"], reverse=True
         ):
-            model_name = model[:35] + "..." if len(model) > 38 else model
-            bare_model = model.split("/", 1)[-1]
+            agent_name, raw_model = self._split_agent_model_key(model)
+            model_name = self._format_agent_model_title(
+                agent_name,
+                raw_model,
+                include_agent=agent_name is not None,
+                max_length=38,
+            )
+            bare_model = self._bare_lookup_key(model)
             token_usage = stats["tokens"]
 
             # Get context usage for this model

--- a/ocmonitor/utils/sqlite_utils.py
+++ b/ocmonitor/utils/sqlite_utils.py
@@ -865,6 +865,7 @@ class SQLiteProcessor:
                         json_extract(m.data, '$.model.modelID'),
                         'unknown'
                     ) as model_id,
+                    COALESCE(NULLIF(json_extract(m.data, '$.agent'), ''), 'main') as agent_name,
                     json_extract(p.data, '$.tool') as tool_name,
                     json_extract(p.data, '$.state.status') as status,
                     COUNT(*) as count
@@ -876,22 +877,29 @@ class SQLiteProcessor:
                   AND json_extract(p.data, '$.type') = 'tool'
                   AND json_extract(p.data, '$.tool') IS NOT NULL
                   AND json_extract(p.data, '$.state.status') IN ('completed', 'error')
-                GROUP BY model_id, tool_name, status
+                GROUP BY agent_name, model_id, tool_name, status
             """
 
             cursor = conn.execute(query, session_ids)
 
-            model_data: Dict[str, Dict[str, Dict[str, int]]] = {}
+            model_data: Dict[str, Dict[str, Any]] = {}
             for row in cursor:
                 model_id = row["model_id"]
+                agent_name = row["agent_name"]
+                group_key = SessionData.agent_model_key(agent_name, model_id)
                 tool_name = row["tool_name"]
                 status = row["status"]
                 count = row["count"]
 
-                if model_id not in model_data:
-                    model_data[model_id] = {}
-                if tool_name not in model_data[model_id]:
-                    model_data[model_id][tool_name] = {
+                if group_key not in model_data:
+                    model_data[group_key] = {
+                        "agent_name": agent_name,
+                        "model_name": model_id,
+                        "tools": {},
+                    }
+                tools = model_data[group_key]["tools"]
+                if tool_name not in tools:
+                    tools[tool_name] = {
                         "success": 0,
                         "failure": 0,
                         "input_tokens": 0,
@@ -901,9 +909,9 @@ class SQLiteProcessor:
                     }
 
                 if status == "completed":
-                    model_data[model_id][tool_name]["success"] += count
+                    tools[tool_name]["success"] += count
                 elif status == "error":
-                    model_data[model_id][tool_name]["failure"] += count
+                    tools[tool_name]["failure"] += count
 
             # Attribute message-level tokens to each model/tool pair. Tokens are
             # stored on assistant messages, not individual tool rows. Split a
@@ -919,6 +927,7 @@ class SQLiteProcessor:
                             json_extract(m.data, '$.model.modelID'),
                             'unknown'
                         ) as model_id,
+                        COALESCE(NULLIF(json_extract(m.data, '$.agent'), ''), 'main') as agent_name,
                         json_extract(p.data, '$.tool') as tool_name,
                         m.data as message_data
                     FROM part p
@@ -937,6 +946,7 @@ class SQLiteProcessor:
                 )
                 SELECT
                     t.model_id,
+                    t.agent_name,
                     t.tool_name,
                     SUM(COALESCE(json_extract(t.message_data, '$.tokens.input'), 0) * 1.0 / mtc.tool_count) as input_tokens,
                     SUM(COALESCE(json_extract(t.message_data, '$.tokens.output'), 0) * 1.0 / mtc.tool_count) as output_tokens,
@@ -946,32 +956,33 @@ class SQLiteProcessor:
                 JOIN message_tool_counts mtc
                   ON t.session_id = mtc.session_id
                  AND t.message_id = mtc.message_id
-                GROUP BY t.model_id, t.tool_name
+                GROUP BY t.agent_name, t.model_id, t.tool_name
             """
 
             token_cursor = conn.execute(token_query, session_ids)
             for row in token_cursor:
                 model_id = row["model_id"]
+                agent_name = row["agent_name"]
+                group_key = SessionData.agent_model_key(agent_name, model_id)
                 tool_name = row["tool_name"]
-                if model_id not in model_data or tool_name not in model_data[model_id]:
+                if group_key not in model_data:
                     continue
-                model_data[model_id][tool_name]["input_tokens"] = round(
-                    row["input_tokens"] or 0
-                )
-                model_data[model_id][tool_name]["output_tokens"] = round(
-                    row["output_tokens"] or 0
-                )
-                model_data[model_id][tool_name]["cache_read_tokens"] = round(
+                tools = model_data[group_key]["tools"]
+                if tool_name not in tools:
+                    continue
+                tools[tool_name]["input_tokens"] = round(row["input_tokens"] or 0)
+                tools[tool_name]["output_tokens"] = round(row["output_tokens"] or 0)
+                tools[tool_name]["cache_read_tokens"] = round(
                     row["cache_read_tokens"] or 0
                 )
-                model_data[model_id][tool_name]["cache_write_tokens"] = round(
+                tools[tool_name]["cache_write_tokens"] = round(
                     row["cache_write_tokens"] or 0
                 )
 
             result = []
-            for model_name, tools in model_data.items():
+            for group in model_data.values():
                 tool_stats = []
-                for tool_name, counts in tools.items():
+                for tool_name, counts in group["tools"].items():
                     total = counts["success"] + counts["failure"]
                     tool_stats.append(
                         ToolUsageStats(
@@ -987,7 +998,11 @@ class SQLiteProcessor:
                     )
                 tool_stats.sort(key=lambda s: s.total_calls, reverse=True)
                 result.append(
-                    ModelToolUsage(model_name=model_name, tool_stats=tool_stats)
+                    ModelToolUsage(
+                        model_name=group["model_name"],
+                        agent_name=group["agent_name"],
+                        tool_stats=tool_stats,
+                    )
                 )
 
             result.sort(key=lambda m: m.total_calls, reverse=True)

--- a/ocmonitor/utils/sqlite_utils.py
+++ b/ocmonitor/utils/sqlite_utils.py
@@ -128,13 +128,21 @@ class SQLiteProcessor:
 
     @classmethod
     def parse_message_data(
-        cls, message_data_str: str, session_id: str
+        cls,
+        message_data_str: str,
+        session_id: str,
+        message_id: Optional[str] = None,
+        time_created: Optional[int] = None,
+        time_updated: Optional[int] = None,
     ) -> Optional[InteractionFile]:
         """Parse a message data JSON string into an InteractionFile.
 
         Args:
             message_data_str: JSON string from message.data column
             session_id: ID of the session this message belongs to
+            message_id: Optional SQLite message ID for related part lookup
+            time_created: Optional SQLite message creation timestamp
+            time_updated: Optional SQLite message update timestamp
 
         Returns:
             InteractionFile object or None if parsing failed
@@ -159,6 +167,13 @@ class SQLiteProcessor:
         model_id = cls._extract_model_name(data).lower()
         provider_id = (data.get("providerID") or "").lower() or None
         finish_reason = data.get("finish")
+        raw_data = dict(data)
+        if message_id is not None:
+            raw_data["_message_id"] = message_id
+        if time_created is not None:
+            raw_data["_message_time_created"] = time_created
+        if time_updated is not None:
+            raw_data["_message_time_updated"] = time_updated
 
         return InteractionFile(
             file_path=Path("sqlite") / session_id,  # Placeholder path
@@ -170,7 +185,7 @@ class SQLiteProcessor:
             project_path=project_path,
             agent=agent,
             finish_reason=finish_reason,
-            raw_data=data,
+            raw_data=raw_data,
         )
 
     @classmethod
@@ -187,13 +202,19 @@ class SQLiteProcessor:
             List of InteractionFile objects
         """
         cursor = conn.execute(
-            "SELECT data FROM message WHERE session_id = ? ORDER BY time_created",
+            "SELECT id, time_created, time_updated, data FROM message WHERE session_id = ? ORDER BY time_created",
             (session_id,),
         )
 
         interactions = []
         for row in cursor:
-            interaction = cls.parse_message_data(row["data"], session_id)
+            interaction = cls.parse_message_data(
+                row["data"],
+                session_id,
+                message_id=row["id"],
+                time_created=row["time_created"],
+                time_updated=row["time_updated"],
+            )
             if interaction:
                 interactions.append(interaction)
 
@@ -463,14 +484,17 @@ class SQLiteProcessor:
         conn = cls._get_connection(db_path)
         try:
             # Get recent parent sessions (no parent_id)
-            parent_rows = conn.execute("""
+            parent_rows = conn.execute(
+                """
                 SELECT s.*, p.worktree as project_path, p.name as project_name
                 FROM session s
                 LEFT JOIN project p ON s.project_id = p.id
                 WHERE s.parent_id IS NULL
                 ORDER BY s.time_created DESC
                 LIMIT ?
-            """, (limit * 5,)).fetchall()
+            """,
+                (limit * 5,),
+            ).fetchall()
 
             if not parent_rows:
                 return []

--- a/ocmonitor/utils/sqlite_utils.py
+++ b/ocmonitor/utils/sqlite_utils.py
@@ -96,10 +96,10 @@ class SQLiteProcessor:
         cache_data = tokens_data.get("cache", {})
 
         return TokenUsage(
-            input=max(0, tokens_data.get('input', 0)),
-            output=max(0, tokens_data.get('output', 0)),
-            cache_write=max(0, cache_data.get('write', 0)),
-            cache_read=max(0, cache_data.get('read', 0))
+            input=max(0, tokens_data.get("input", 0)),
+            output=max(0, tokens_data.get("output", 0)),
+            cache_write=max(0, cache_data.get("write", 0)),
+            cache_read=max(0, cache_data.get("read", 0)),
         )
 
     @staticmethod
@@ -673,39 +673,37 @@ class SQLiteProcessor:
             return stats
         finally:
             conn.close()
-    
+
     @classmethod
     def load_tool_usage_for_sessions(
-        cls,
-        session_ids: List[str],
-        db_path: Optional[Path] = None
+        cls, session_ids: List[str], db_path: Optional[Path] = None
     ) -> List[ToolUsageStats]:
         """Load tool usage statistics for the given sessions.
-        
+
         Queries the `part` table for tool entries with terminal statuses
         (completed or error) and aggregates counts by tool name.
-        
+
         Args:
             session_ids: List of session IDs to aggregate tool usage for
             db_path: Path to database (uses default if not provided)
-            
+
         Returns:
             List of ToolUsageStats sorted by total_calls descending
         """
         if not session_ids:
             return []
-        
+
         if db_path is None:
             db_path = cls.find_database_path()
-        
+
         if not db_path or not db_path.exists():
             return []
-        
+
         conn = cls._get_connection(db_path)
         try:
             # Build placeholders for IN clause
-            placeholders = ','.join('?' * len(session_ids))
-            
+            placeholders = ",".join("?" * len(session_ids))
+
             # Query tool parts with terminal statuses
             # Use json_valid to protect against malformed JSON
             # Use json_extract to access nested fields in the data column
@@ -722,73 +720,144 @@ class SQLiteProcessor:
                   AND json_extract(data, '$.state.status') IN ('completed', 'error')
                 GROUP BY tool_name, status
             """
-            
+
             cursor = conn.execute(query, session_ids)
-            
+
             # Aggregate by tool name
             tool_data: Dict[str, Dict[str, int]] = {}
             for row in cursor:
-                tool_name = row['tool_name']
-                status = row['status']
-                count = row['count']
-                
+                tool_name = row["tool_name"]
+                status = row["status"]
+                count = row["count"]
+
                 if tool_name not in tool_data:
-                    tool_data[tool_name] = {'success': 0, 'failure': 0}
-                
-                if status == 'completed':
-                    tool_data[tool_name]['success'] += count
-                elif status == 'error':
-                    tool_data[tool_name]['failure'] += count
-            
+                    tool_data[tool_name] = {
+                        "success": 0,
+                        "failure": 0,
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "cache_read_tokens": 0,
+                        "cache_write_tokens": 0,
+                    }
+
+                if status == "completed":
+                    tool_data[tool_name]["success"] += count
+                elif status == "error":
+                    tool_data[tool_name]["failure"] += count
+
+            # Attribute message-level tokens to tools. OpenCode records tokens on
+            # assistant messages, while tool calls are separate part rows. For a
+            # message with multiple terminal tool calls, split the message tokens
+            # evenly across those calls to avoid double-counting.
+            token_query = f"""
+                WITH terminal_tools AS (
+                    SELECT
+                        p.session_id,
+                        p.message_id,
+                        json_extract(p.data, '$.tool') as tool_name,
+                        m.data as message_data
+                    FROM part p
+                    JOIN message m ON p.message_id = m.id
+                    WHERE p.session_id IN ({placeholders})
+                      AND json_valid(p.data) = 1
+                      AND json_valid(m.data) = 1
+                      AND json_extract(p.data, '$.type') = 'tool'
+                      AND json_extract(p.data, '$.tool') IS NOT NULL
+                      AND json_extract(p.data, '$.state.status') IN ('completed', 'error')
+                ),
+                message_tool_counts AS (
+                    SELECT session_id, message_id, COUNT(*) as tool_count
+                    FROM terminal_tools
+                    GROUP BY session_id, message_id
+                )
+                SELECT
+                    t.tool_name,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.input'), 0) * 1.0 / mtc.tool_count) as input_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.output'), 0) * 1.0 / mtc.tool_count) as output_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.cache.read'), 0) * 1.0 / mtc.tool_count) as cache_read_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.cache.write'), 0) * 1.0 / mtc.tool_count) as cache_write_tokens
+                FROM terminal_tools t
+                JOIN message_tool_counts mtc
+                  ON t.session_id = mtc.session_id
+                 AND t.message_id = mtc.message_id
+                GROUP BY t.tool_name
+            """
+
+            try:
+                token_cursor = conn.execute(token_query, session_ids)
+                for row in token_cursor:
+                    tool_name = row["tool_name"]
+                    if tool_name not in tool_data:
+                        continue
+                    tool_data[tool_name]["input_tokens"] = round(
+                        row["input_tokens"] or 0
+                    )
+                    tool_data[tool_name]["output_tokens"] = round(
+                        row["output_tokens"] or 0
+                    )
+                    tool_data[tool_name]["cache_read_tokens"] = round(
+                        row["cache_read_tokens"] or 0
+                    )
+                    tool_data[tool_name]["cache_write_tokens"] = round(
+                        row["cache_write_tokens"] or 0
+                    )
+            except sqlite3.OperationalError:
+                # Legacy/minimal DBs may not have a message table; keep counts.
+                pass
+
             # Build ToolUsageStats list
             stats = []
             for tool_name, counts in tool_data.items():
-                total = counts['success'] + counts['failure']
-                stats.append(ToolUsageStats(
-                    tool_name=tool_name,
-                    total_calls=total,
-                    success_count=counts['success'],
-                    failure_count=counts['failure']
-                ))
-            
+                total = counts["success"] + counts["failure"]
+                stats.append(
+                    ToolUsageStats(
+                        tool_name=tool_name,
+                        total_calls=total,
+                        success_count=counts["success"],
+                        failure_count=counts["failure"],
+                        input_tokens=counts["input_tokens"],
+                        output_tokens=counts["output_tokens"],
+                        cache_read_tokens=counts["cache_read_tokens"],
+                        cache_write_tokens=counts["cache_write_tokens"],
+                    )
+                )
+
             # Sort by total_calls descending
             stats.sort(key=lambda s: s.total_calls, reverse=True)
-            
+
             return stats
         finally:
             conn.close()
 
     @classmethod
     def load_tool_usage_by_model_for_sessions(
-        cls,
-        session_ids: List[str],
-        db_path: Optional[Path] = None
+        cls, session_ids: List[str], db_path: Optional[Path] = None
     ) -> List[ModelToolUsage]:
         """Load tool usage statistics grouped by model for the given sessions.
-        
+
         Queries the `part` table joined with `message` to get model information
         for each tool call. Aggregates counts by model and tool name.
-        
+
         Args:
             session_ids: List of session IDs to aggregate tool usage for
             db_path: Path to database (uses default if not provided)
-            
+
         Returns:
             List of ModelToolUsage sorted by total_calls descending
         """
         if not session_ids:
             return []
-        
+
         if db_path is None:
             db_path = cls.find_database_path()
-        
+
         if not db_path or not db_path.exists():
             return []
-        
+
         conn = cls._get_connection(db_path)
         try:
-            placeholders = ','.join('?' * len(session_ids))
-            
+            placeholders = ",".join("?" * len(session_ids))
+
             query = f"""
                 SELECT 
                     COALESCE(
@@ -809,43 +878,118 @@ class SQLiteProcessor:
                   AND json_extract(p.data, '$.state.status') IN ('completed', 'error')
                 GROUP BY model_id, tool_name, status
             """
-            
+
             cursor = conn.execute(query, session_ids)
-            
+
             model_data: Dict[str, Dict[str, Dict[str, int]]] = {}
             for row in cursor:
-                model_id = row['model_id']
-                tool_name = row['tool_name']
-                status = row['status']
-                count = row['count']
-                
+                model_id = row["model_id"]
+                tool_name = row["tool_name"]
+                status = row["status"]
+                count = row["count"]
+
                 if model_id not in model_data:
                     model_data[model_id] = {}
                 if tool_name not in model_data[model_id]:
-                    model_data[model_id][tool_name] = {'success': 0, 'failure': 0}
-                
-                if status == 'completed':
-                    model_data[model_id][tool_name]['success'] += count
-                elif status == 'error':
-                    model_data[model_id][tool_name]['failure'] += count
-            
+                    model_data[model_id][tool_name] = {
+                        "success": 0,
+                        "failure": 0,
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "cache_read_tokens": 0,
+                        "cache_write_tokens": 0,
+                    }
+
+                if status == "completed":
+                    model_data[model_id][tool_name]["success"] += count
+                elif status == "error":
+                    model_data[model_id][tool_name]["failure"] += count
+
+            # Attribute message-level tokens to each model/tool pair. Tokens are
+            # stored on assistant messages, not individual tool rows. Split a
+            # message's tokens evenly across its terminal tool calls to avoid
+            # over-counting when multiple tools share one message.
+            token_query = f"""
+                WITH terminal_tools AS (
+                    SELECT
+                        p.session_id,
+                        p.message_id,
+                        COALESCE(
+                            json_extract(m.data, '$.modelID'),
+                            json_extract(m.data, '$.model.modelID'),
+                            'unknown'
+                        ) as model_id,
+                        json_extract(p.data, '$.tool') as tool_name,
+                        m.data as message_data
+                    FROM part p
+                    JOIN message m ON p.message_id = m.id
+                    WHERE p.session_id IN ({placeholders})
+                      AND json_valid(p.data) = 1
+                      AND json_valid(m.data) = 1
+                      AND json_extract(p.data, '$.type') = 'tool'
+                      AND json_extract(p.data, '$.tool') IS NOT NULL
+                      AND json_extract(p.data, '$.state.status') IN ('completed', 'error')
+                ),
+                message_tool_counts AS (
+                    SELECT session_id, message_id, COUNT(*) as tool_count
+                    FROM terminal_tools
+                    GROUP BY session_id, message_id
+                )
+                SELECT
+                    t.model_id,
+                    t.tool_name,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.input'), 0) * 1.0 / mtc.tool_count) as input_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.output'), 0) * 1.0 / mtc.tool_count) as output_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.cache.read'), 0) * 1.0 / mtc.tool_count) as cache_read_tokens,
+                    SUM(COALESCE(json_extract(t.message_data, '$.tokens.cache.write'), 0) * 1.0 / mtc.tool_count) as cache_write_tokens
+                FROM terminal_tools t
+                JOIN message_tool_counts mtc
+                  ON t.session_id = mtc.session_id
+                 AND t.message_id = mtc.message_id
+                GROUP BY t.model_id, t.tool_name
+            """
+
+            token_cursor = conn.execute(token_query, session_ids)
+            for row in token_cursor:
+                model_id = row["model_id"]
+                tool_name = row["tool_name"]
+                if model_id not in model_data or tool_name not in model_data[model_id]:
+                    continue
+                model_data[model_id][tool_name]["input_tokens"] = round(
+                    row["input_tokens"] or 0
+                )
+                model_data[model_id][tool_name]["output_tokens"] = round(
+                    row["output_tokens"] or 0
+                )
+                model_data[model_id][tool_name]["cache_read_tokens"] = round(
+                    row["cache_read_tokens"] or 0
+                )
+                model_data[model_id][tool_name]["cache_write_tokens"] = round(
+                    row["cache_write_tokens"] or 0
+                )
+
             result = []
             for model_name, tools in model_data.items():
                 tool_stats = []
                 for tool_name, counts in tools.items():
-                    total = counts['success'] + counts['failure']
-                    tool_stats.append(ToolUsageStats(
-                        tool_name=tool_name,
-                        total_calls=total,
-                        success_count=counts['success'],
-                        failure_count=counts['failure']
-                    ))
+                    total = counts["success"] + counts["failure"]
+                    tool_stats.append(
+                        ToolUsageStats(
+                            tool_name=tool_name,
+                            total_calls=total,
+                            success_count=counts["success"],
+                            failure_count=counts["failure"],
+                            input_tokens=counts["input_tokens"],
+                            output_tokens=counts["output_tokens"],
+                            cache_read_tokens=counts["cache_read_tokens"],
+                            cache_write_tokens=counts["cache_write_tokens"],
+                        )
+                    )
                 tool_stats.sort(key=lambda s: s.total_calls, reverse=True)
-                result.append(ModelToolUsage(
-                    model_name=model_name,
-                    tool_stats=tool_stats
-                ))
-            
+                result.append(
+                    ModelToolUsage(model_name=model_name, tool_stats=tool_stats)
+                )
+
             result.sort(key=lambda m: m.total_calls, reverse=True)
 
             return result
@@ -893,13 +1037,18 @@ class SQLiteProcessor:
                 """,
                 (f"%{query.lower()}%",),
             )
-            return [row["model_name"] for row in cursor if row["model_name"] != "unknown"]
+            return [
+                row["model_name"] for row in cursor if row["model_name"] != "unknown"
+            ]
         finally:
             conn.close()
 
     @classmethod
     def get_model_detail_stats(
-        cls, model_name: str, pricing_data: Dict[str, Any], db_path: Optional[Path] = None
+        cls,
+        model_name: str,
+        pricing_data: Dict[str, Any],
+        db_path: Optional[Path] = None,
     ) -> Optional[ModelDetailStats]:
         """Get detailed statistics for a single model.
 
@@ -973,28 +1122,40 @@ class SQLiteProcessor:
             )
 
             # Calculate cost using pricing data
-            total_cost = Decimal('0.0')
+            total_cost = Decimal("0.0")
             model_pricing = FileProcessor.lookup_pricing(
                 pricing_data,
                 model_id=model_name,
                 provider_id=None,
             )
             if model_pricing:
-                price_input = getattr(model_pricing, 'input', 0) or 0
-                price_output = getattr(model_pricing, 'output', 0) or 0
-                price_cache_read = getattr(model_pricing, 'cacheRead', 0) or 0
-                price_cache_write = getattr(model_pricing, 'cacheWrite', 0) or 0
+                price_input = getattr(model_pricing, "input", 0) or 0
+                price_output = getattr(model_pricing, "output", 0) or 0
+                price_cache_read = getattr(model_pricing, "cacheRead", 0) or 0
+                price_cache_write = getattr(model_pricing, "cacheWrite", 0) or 0
                 total_cost = (
-                    Decimal(str(tokens.input)) * Decimal(str(price_input)) / Decimal('1000000')
-                    + Decimal(str(tokens.output)) * Decimal(str(price_output)) / Decimal('1000000')
-                    + Decimal(str(tokens.cache_read)) * Decimal(str(price_cache_read)) / Decimal('1000000')
-                    + Decimal(str(tokens.cache_write)) * Decimal(str(price_cache_write)) / Decimal('1000000')
+                    Decimal(str(tokens.input))
+                    * Decimal(str(price_input))
+                    / Decimal("1000000")
+                    + Decimal(str(tokens.output))
+                    * Decimal(str(price_output))
+                    / Decimal("1000000")
+                    + Decimal(str(tokens.cache_read))
+                    * Decimal(str(price_cache_read))
+                    / Decimal("1000000")
+                    + Decimal(str(tokens.cache_write))
+                    * Decimal(str(price_cache_write))
+                    / Decimal("1000000")
                 )
 
             total_sessions = row["total_sessions"]
             total_days = row["total_days"]
-            avg_cost_per_day = total_cost / total_days if total_days > 0 else Decimal('0.0')
-            avg_cost_per_session = total_cost / total_sessions if total_sessions > 0 else Decimal('0.0')
+            avg_cost_per_day = (
+                total_cost / total_days if total_days > 0 else Decimal("0.0")
+            )
+            avg_cost_per_session = (
+                total_cost / total_sessions if total_sessions > 0 else Decimal("0.0")
+            )
 
             # Query 2: Per-interaction output rates for p50 calculation
             rate_cursor = conn.execute(
@@ -1062,12 +1223,14 @@ class SQLiteProcessor:
 
             tool_stats = []
             for tool_row in tool_cursor:
-                tool_stats.append(ToolUsageStats(
-                    tool_name=tool_row["tool_name"],
-                    total_calls=tool_row["total_calls"],
-                    success_count=tool_row["success"],
-                    failure_count=tool_row["failed"],
-                ))
+                tool_stats.append(
+                    ToolUsageStats(
+                        tool_name=tool_row["tool_name"],
+                        total_calls=tool_row["total_calls"],
+                        success_count=tool_row["success"],
+                        failure_count=tool_row["failed"],
+                    )
+                )
 
             tool_summary = ToolUsageSummary(tool_stats=tool_stats)
 

--- a/ocmonitor/utils/sqlite_utils.py
+++ b/ocmonitor/utils/sqlite_utils.py
@@ -439,6 +439,109 @@ class SQLiteProcessor:
             conn.close()
 
     @classmethod
+    def get_recent_workflows(
+        cls, db_path: Optional[Path] = None, limit: int = 5
+    ) -> List[Dict[str, Any]]:
+        """Get the most recent workflows (parent session + sub-agents).
+
+        Finds parent sessions that have actual message data (interactions),
+        skipping empty sessions, up to the specified limit.
+
+        Args:
+            db_path: Path to database (uses default if not provided)
+            limit: Maximum number of workflows to return
+
+        Returns:
+            List of dictionaries with workflow data compatible with SessionWorkflow.
+        """
+        if db_path is None:
+            db_path = cls.find_database_path()
+
+        if not db_path or not db_path.exists():
+            return []
+
+        conn = cls._get_connection(db_path)
+        try:
+            # Get recent parent sessions (no parent_id)
+            parent_rows = conn.execute("""
+                SELECT s.*, p.worktree as project_path, p.name as project_name
+                FROM session s
+                LEFT JOIN project p ON s.project_id = p.id
+                WHERE s.parent_id IS NULL
+                ORDER BY s.time_created DESC
+                LIMIT ?
+            """, (limit * 5,)).fetchall()
+
+            if not parent_rows:
+                return []
+
+            workflows = []
+            for parent_row in parent_rows:
+                session = cls.load_session_data(conn, parent_row)
+                if session and session.files:  # Has interactions
+                    workflows.append(cls._build_workflow_dict(conn, session))
+                    if len(workflows) >= limit:
+                        break
+
+            return workflows
+        finally:
+            conn.close()
+
+    @classmethod
+    def get_workflow_by_id(
+        cls, workflow_id: str, db_path: Optional[Path] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Get a specific workflow by its ID (main session or sub-agent ID)."""
+        if db_path is None:
+            db_path = cls.find_database_path()
+
+        if not db_path or not db_path.exists():
+            return None
+
+        conn = cls._get_connection(db_path)
+        try:
+            # First, check if the session exists and get its parent_id
+            row = conn.execute(
+                """
+                SELECT s.*, p.worktree as project_path, p.name as project_name
+                FROM session s
+                LEFT JOIN project p ON s.project_id = p.id
+                WHERE s.id = ?
+            """,
+                (workflow_id,),
+            ).fetchone()
+
+            if not row:
+                return None
+
+            parent_id = row["parent_id"]
+            if parent_id:
+                # It's a sub-agent, load the parent session instead
+                parent_row = conn.execute(
+                    """
+                    SELECT s.*, p.worktree as project_path, p.name as project_name
+                    FROM session s
+                    LEFT JOIN project p ON s.project_id = p.id
+                    WHERE s.id = ?
+                """,
+                    (parent_id,),
+                ).fetchone()
+                if parent_row:
+                    main_session = cls.load_session_data(conn, parent_row)
+                else:
+                    # Parent not found (orphan), treat the sub-agent as its own main
+                    main_session = cls.load_session_data(conn, row)
+            else:
+                main_session = cls.load_session_data(conn, row)
+
+            if not main_session:
+                return None
+
+            return cls._build_workflow_dict(conn, main_session)
+        finally:
+            conn.close()
+
+    @classmethod
     def _build_workflow_dict(
         cls, conn: sqlite3.Connection, main_session: SessionData
     ) -> Dict[str, Any]:

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -656,6 +656,48 @@ class TestLiveCommand:
         assert captured["kwargs"]["selected_session_id"] == "explicit-session"
         assert captured["kwargs"]["interactive_switch"] is True
 
+    def test_live_last_limits_picker_workflows(self, mock_sessions_dir):
+        """Test --last flag is passed through to the workflow retrieval methods."""
+        runner = CliRunner()
+        captured_limit = {}
+
+        def fake_get_file_workflows(self, base_path, **kwargs):
+            captured_limit["limit"] = kwargs.get("limit")
+            return []
+
+        with patch(
+            "ocmonitor.services.live_monitor.LiveMonitor.validate_monitoring_setup",
+            return_value={
+                "valid": True,
+                "issues": [],
+                "warnings": [],
+                "info": {"sqlite": {"available": False}, "files": {"available": True}},
+            },
+        ), patch(
+            "ocmonitor.services.live_monitor.LiveMonitor._get_file_active_workflows",
+            new=fake_get_file_workflows,
+        ), patch(
+            "ocmonitor.services.live_monitor.LiveMonitor._prompt_for_workflow_selection",
+            return_value="picked-workflow",
+        ), patch(
+            "ocmonitor.services.live_monitor.LiveMonitor.start_monitoring",
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "live",
+                    str(mock_sessions_dir),
+                    "--source",
+                    "files",
+                    "--pick",
+                    "--last",
+                    "5",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert captured_limit.get("limit") == 5
+
 
 class TestMetricsCommand:
     """Tests for metrics CLI command."""

--- a/tests/unit/test_live_monitor.py
+++ b/tests/unit/test_live_monitor.py
@@ -887,6 +887,29 @@ class TestLiveMonitorSelection:
         )
         assert result == []
 
+    def test_file_loader_falls_back_to_recent_workflows(self, monkeypatch, tmp_path):
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+
+        ended_workflows = [
+            SimpleNamespace(workflow_id=f"wf-{i}", end_time=1)
+            for i in range(10)
+        ]
+        monkeypatch.setattr(
+            "ocmonitor.services.live_monitor.FileProcessor.load_all_sessions",
+            lambda base_path, limit=50: [SimpleNamespace(session_id="ses_1")],
+        )
+        monkeypatch.setattr(
+            monitor.session_grouper,
+            "group_sessions",
+            lambda sessions: ended_workflows,
+        )
+
+        result = monitor._get_file_active_workflows(
+            str(tmp_path), allow_fallback=True
+        )
+        assert len(result) == 5
+        assert [w.workflow_id for w in result] == [f"wf-{i}" for i in range(5)]
+
     def test_sqlite_loader_disables_fallback_in_pinned_mode(self, monkeypatch, tmp_path):
         monitor = LiveMonitor(pricing_data={}, init_from_db=False)
 
@@ -901,12 +924,34 @@ class TestLiveMonitorSelection:
             lambda _: [],
         )
         monkeypatch.setattr(
-            "ocmonitor.services.live_monitor.SQLiteProcessor.get_most_recent_workflow",
-            lambda _: {"workflow_id": "wf-ended"},
+            "ocmonitor.services.live_monitor.SQLiteProcessor.get_recent_workflows",
+            lambda _, limit=5: [{"workflow_id": "wf-ended"}],
         )
 
         result = monitor._get_sqlite_active_workflows(allow_fallback=False)
         assert result == []
+
+    def test_sqlite_loader_falls_back_to_recent_workflows(self, monkeypatch, tmp_path):
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+
+        db_path = tmp_path / "opencode.db"
+        db_path.touch()
+        monkeypatch.setattr(
+            "ocmonitor.services.live_monitor.SQLiteProcessor.find_database_path",
+            lambda: db_path,
+        )
+        monkeypatch.setattr(
+            "ocmonitor.services.live_monitor.SQLiteProcessor.get_all_active_workflows",
+            lambda _: [],
+        )
+        monkeypatch.setattr(
+            "ocmonitor.services.live_monitor.SQLiteProcessor.get_recent_workflows",
+            lambda _, limit=5: [{"workflow_id": f"wf-{i}"} for i in range(limit)],
+        )
+
+        result = monitor._get_sqlite_active_workflows(allow_fallback=True)
+        assert len(result) == 5
+        assert [w["workflow_id"] for w in result] == [f"wf-{i}" for i in range(5)]
 
     def test_handle_live_switch_command_show_does_not_switch(self):
         monitor = LiveMonitor(pricing_data={}, init_from_db=False)

--- a/tests/unit/test_live_monitor.py
+++ b/tests/unit/test_live_monitor.py
@@ -796,7 +796,10 @@ class TestLiveMonitorSelection:
         workflow_a = {
             "workflow_id": "workflow-a",
             "main_session": MagicMock(session_id="main-a"),
-            "all_sessions": [MagicMock(session_id="main-a"), MagicMock(session_id="sub-a1")],
+            "all_sessions": [
+                MagicMock(session_id="main-a"),
+                MagicMock(session_id="sub-a1"),
+            ],
             "display_title": "Workflow A",
             "project_name": "proj-a",
             "session_count": 2,
@@ -882,17 +885,14 @@ class TestLiveMonitorSelection:
             lambda sessions: [ended_workflow],
         )
 
-        result = monitor._get_file_active_workflows(
-            str(tmp_path), allow_fallback=False
-        )
+        result = monitor._get_file_active_workflows(str(tmp_path), allow_fallback=False)
         assert result == []
 
     def test_file_loader_falls_back_to_recent_workflows(self, monkeypatch, tmp_path):
         monitor = LiveMonitor(pricing_data={}, init_from_db=False)
 
         ended_workflows = [
-            SimpleNamespace(workflow_id=f"wf-{i}", end_time=1)
-            for i in range(10)
+            SimpleNamespace(workflow_id=f"wf-{i}", end_time=1) for i in range(10)
         ]
         monkeypatch.setattr(
             "ocmonitor.services.live_monitor.FileProcessor.load_all_sessions",
@@ -904,13 +904,13 @@ class TestLiveMonitorSelection:
             lambda sessions: ended_workflows,
         )
 
-        result = monitor._get_file_active_workflows(
-            str(tmp_path), allow_fallback=True
-        )
+        result = monitor._get_file_active_workflows(str(tmp_path), allow_fallback=True)
         assert len(result) == 5
         assert [w.workflow_id for w in result] == [f"wf-{i}" for i in range(5)]
 
-    def test_sqlite_loader_disables_fallback_in_pinned_mode(self, monkeypatch, tmp_path):
+    def test_sqlite_loader_disables_fallback_in_pinned_mode(
+        self, monkeypatch, tmp_path
+    ):
         monitor = LiveMonitor(pricing_data={}, init_from_db=False)
 
         db_path = tmp_path / "opencode.db"
@@ -992,9 +992,7 @@ class TestLiveMonitorSelection:
     def test_apply_switch_command_selection_only_switches_on_new_id(self):
         monitor = LiveMonitor(pricing_data={}, init_from_db=False)
 
-        selected, switched = monitor._apply_switch_command_selection(
-            None, "wf-1", None
-        )
+        selected, switched = monitor._apply_switch_command_selection(None, "wf-1", None)
         assert switched is False
         assert selected is None
 
@@ -1191,7 +1189,9 @@ class TestExecuteWorkflowSwitch:
 class TestHandleListCommand:
     """Tests for the _handle_list_command refactored method."""
 
-    def test_handle_list_command_returns_unchanged_when_no_picker_selection(self, tmp_path):
+    def test_handle_list_command_returns_unchanged_when_no_picker_selection(
+        self, tmp_path
+    ):
         """Should return unchanged state when picker returns None."""
         from ocmonitor.services.live_monitor import LiveMonitor
         from ocmonitor.config import PathsConfig
@@ -1271,16 +1271,18 @@ class TestHandleNavigationCommand:
         mock_workflow = MagicMock()
         mock_workflow.workflow_id = "wf-1"
 
-        should_quit, workflow_id, workflow, selected = monitor._handle_navigation_command(
-            command="q",
-            descriptors=[{"workflow_id": "wf-1"}],
-            selected_session_id="wf-1",
-            current_workflow_id="wf-1",
-            current_workflow=mock_workflow,
-            active_workflows=[mock_workflow],
-            live=MagicMock(),
-            interactive_switch=True,
-            refresh_interval=5,
+        should_quit, workflow_id, workflow, selected = (
+            monitor._handle_navigation_command(
+                command="q",
+                descriptors=[{"workflow_id": "wf-1"}],
+                selected_session_id="wf-1",
+                current_workflow_id="wf-1",
+                current_workflow=mock_workflow,
+                active_workflows=[mock_workflow],
+                live=MagicMock(),
+                interactive_switch=True,
+                refresh_interval=5,
+            )
         )
 
         assert should_quit is True
@@ -1309,16 +1311,18 @@ class TestHandleNavigationCommand:
 
         live_mock = MagicMock()
 
-        should_quit, workflow_id, workflow, selected = monitor._handle_navigation_command(
-            command="n",
-            descriptors=[{"workflow_id": "wf-1"}, {"workflow_id": "wf-2"}],
-            selected_session_id=None,
-            current_workflow_id="wf-1",
-            current_workflow=workflow_1,
-            active_workflows=[workflow_1, workflow_2],
-            live=live_mock,
-            interactive_switch=True,
-            refresh_interval=5,
+        should_quit, workflow_id, workflow, selected = (
+            monitor._handle_navigation_command(
+                command="n",
+                descriptors=[{"workflow_id": "wf-1"}, {"workflow_id": "wf-2"}],
+                selected_session_id=None,
+                current_workflow_id="wf-1",
+                current_workflow=workflow_1,
+                active_workflows=[workflow_1, workflow_2],
+                live=live_mock,
+                interactive_switch=True,
+                refresh_interval=5,
+            )
         )
 
         assert should_quit is False
@@ -1348,16 +1352,18 @@ class TestHandleNavigationCommand:
 
         live_mock = MagicMock()
 
-        should_quit, workflow_id, workflow, selected = monitor._handle_navigation_command(
-            command="p",
-            descriptors=[{"workflow_id": "wf-1"}, {"workflow_id": "wf-2"}],
-            selected_session_id=None,
-            current_workflow_id="wf-2",
-            current_workflow=workflow_2,
-            active_workflows=[workflow_1, workflow_2],
-            live=live_mock,
-            interactive_switch=True,
-            refresh_interval=5,
+        should_quit, workflow_id, workflow, selected = (
+            monitor._handle_navigation_command(
+                command="p",
+                descriptors=[{"workflow_id": "wf-1"}, {"workflow_id": "wf-2"}],
+                selected_session_id=None,
+                current_workflow_id="wf-2",
+                current_workflow=workflow_2,
+                active_workflows=[workflow_1, workflow_2],
+                live=live_mock,
+                interactive_switch=True,
+                refresh_interval=5,
+            )
         )
 
         assert should_quit is False
@@ -1390,20 +1396,22 @@ class TestHandleNavigationCommand:
 
         live_mock = MagicMock()
 
-        should_quit, workflow_id, workflow, selected = monitor._handle_navigation_command(
-            command="3",
-            descriptors=[
-                {"workflow_id": "wf-1"},
-                {"workflow_id": "wf-2"},
-                {"workflow_id": "wf-3"},
-            ],
-            selected_session_id=None,
-            current_workflow_id="wf-1",
-            current_workflow=workflow_1,
-            active_workflows=[workflow_1, workflow_2, workflow_3],
-            live=live_mock,
-            interactive_switch=True,
-            refresh_interval=5,
+        should_quit, workflow_id, workflow, selected = (
+            monitor._handle_navigation_command(
+                command="3",
+                descriptors=[
+                    {"workflow_id": "wf-1"},
+                    {"workflow_id": "wf-2"},
+                    {"workflow_id": "wf-3"},
+                ],
+                selected_session_id=None,
+                current_workflow_id="wf-1",
+                current_workflow=workflow_1,
+                active_workflows=[workflow_1, workflow_2, workflow_3],
+                live=live_mock,
+                interactive_switch=True,
+                refresh_interval=5,
+            )
         )
 
         assert should_quit is False
@@ -1432,7 +1440,10 @@ class TestLiveMonitorProviderAwareRegressions:
             )
         }
 
-        monitor = LiveMonitor(pricing_data=pricing_data, paths_config=PathsConfig(messages_dir=str(tmp_path)))
+        monitor = LiveMonitor(
+            pricing_data=pricing_data,
+            paths_config=PathsConfig(messages_dir=str(tmp_path)),
+        )
 
         inter_file = tmp_path / "inter_0001.json"
         inter_file.write_text("{}")
@@ -1454,3 +1465,253 @@ class TestLiveMonitorProviderAwareRegressions:
 
         assert "claude-sonnet-4.5" in result
         assert result["claude-sonnet-4.5"]["context_window"] == 100000
+
+
+class TestRecentTurnInspection:
+    """Tests for live-monitor recent-turn history inspection."""
+
+    def _make_turn(self, tmp_path, session_id, name, created, total_output=100):
+        from ocmonitor.models.session import InteractionFile, TimeData, TokenUsage
+
+        path = tmp_path / name
+        path.write_text("{}")
+        return InteractionFile(
+            file_path=path,
+            session_id=session_id,
+            model_id="claude-sonnet-4.5",
+            provider_id="github-copilot",
+            tokens=TokenUsage(
+                input=1000,
+                output=total_output,
+                cache_read=200,
+                cache_write=50,
+            ),
+            time_data=TimeData(created=created, completed=created + 2000),
+            project_path=str(tmp_path),
+            agent="build",
+            finish_reason="stop",
+            raw_data={
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": f"Assistant summary for {name}"},
+                    {
+                        "type": "tool",
+                        "tool": "bash",
+                        "state": {"status": "completed", "input": "pytest -q"},
+                    },
+                ],
+                "user": f"User request for {name}",
+            },
+        )
+
+    def test_describe_recent_turns_orders_by_activity_and_limits(self, tmp_path):
+        from ocmonitor.models.session import SessionData
+
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        older = self._make_turn(tmp_path, "ses-1", "older.json", 1_000)
+        newer = self._make_turn(tmp_path, "ses-1", "newer.json", 3_000)
+        newest = self._make_turn(tmp_path, "ses-2", "newest.json", 5_000)
+        workflow = SimpleNamespace(
+            all_sessions=[
+                SessionData(session_id="ses-1", files=[older, newer]),
+                SessionData(session_id="ses-2", files=[newest]),
+            ]
+        )
+
+        descriptors = monitor._describe_recent_turns(workflow, limit=2)
+
+        assert [d["turn"].file_name for d in descriptors] == [
+            "newest.json",
+            "newer.json",
+        ]
+        assert descriptors[0]["tokens_total"] == newest.tokens.total
+
+    def test_prompt_for_recent_turn_selection_accepts_number(self, tmp_path):
+        from ocmonitor.models.session import SessionData
+
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        turn = self._make_turn(tmp_path, "ses-1", "turn.json", 1_000)
+        workflow = SimpleNamespace(
+            all_sessions=[SessionData(session_id="ses-1", files=[turn])]
+        )
+        monitor._print_recent_turn_picker_table = MagicMock()
+        monitor.console.input = MagicMock(return_value="1")
+
+        selected = monitor._prompt_for_recent_turn_selection(workflow, "Recent Turns")
+
+        assert selected is turn
+
+    def test_prompt_for_recent_turn_selection_paginates(self, tmp_path):
+        from ocmonitor.models.session import SessionData
+
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        turns = [
+            self._make_turn(tmp_path, "ses-1", f"turn-{idx}.json", idx * 1000)
+            for idx in range(52)
+        ]
+        workflow = SimpleNamespace(
+            all_sessions=[SessionData(session_id="ses-1", files=turns)]
+        )
+        monitor._print_recent_turn_picker_table = MagicMock()
+        monitor.console.input = MagicMock(side_effect=["n", "51"])
+
+        selected = monitor._prompt_for_recent_turn_selection(workflow, "Recent Turns")
+
+        assert selected is turns[1]
+        assert monitor._print_recent_turn_picker_table.call_args_list[0].args[2] == 0
+        assert monitor._print_recent_turn_picker_table.call_args_list[1].args[2] == 1
+
+    def test_prompt_for_recent_turn_selection_refreshes_turns(self, tmp_path):
+        from ocmonitor.models.session import SessionData
+
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        old_turn = self._make_turn(tmp_path, "ses-1", "old.json", 1_000)
+        new_turn = self._make_turn(tmp_path, "ses-1", "new.json", 3_000)
+        workflow = SimpleNamespace(
+            all_sessions=[SessionData(session_id="ses-1", files=[old_turn])]
+        )
+        refreshed_workflow = SimpleNamespace(
+            all_sessions=[SessionData(session_id="ses-1", files=[new_turn])]
+        )
+        monitor._print_recent_turn_picker_table = MagicMock()
+        monitor.console.input = MagicMock(side_effect=["r", "1"])
+        refresh_workflow = MagicMock(return_value=refreshed_workflow)
+
+        selected = monitor._prompt_for_recent_turn_selection(
+            workflow, "Recent Turns", refresh_workflow=refresh_workflow
+        )
+
+        assert selected is new_turn
+        refresh_workflow.assert_called_once()
+        assert monitor._print_recent_turn_picker_table.call_count == 2
+
+    def test_turn_message_and_tool_summaries_use_raw_data(self, tmp_path):
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        turn = self._make_turn(tmp_path, "ses-1", "turn.json", 1_000)
+
+        message = monitor._extract_turn_message_summary(turn)
+        tools = monitor._extract_turn_tool_summary(turn)
+
+        assert message["user"] == "User request for turn.json"
+        assert "Assistant summary" in message["assistant"]
+        assert tools == [
+            {"tool": "bash", "status": "completed", "summary": "pytest -q"}
+        ]
+
+    def test_turn_activity_uses_sqlite_message_metadata_fallback(self, tmp_path):
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        turn = self._make_turn(tmp_path, "ses-1", "turn.json", 1_000)
+        turn.time_data = None
+        turn.raw_data["_message_time_created"] = 10_000
+        turn.raw_data["_message_time_updated"] = 12_000
+
+        assert monitor._get_turn_activity_ts(turn) == 12.0
+
+    def test_turn_message_summary_uses_sqlite_part_text_and_user_message(
+        self, tmp_path
+    ):
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        turn = self._make_turn(tmp_path, "ses-1", "turn.json", 1_000)
+        turn.raw_data = {
+            "role": "assistant",
+            "_message_id": "msg-2",
+            "_message_time_created": 2_000,
+        }
+        monitor._load_sqlite_part_payloads_for_turn = MagicMock(
+            return_value=[{"type": "text", "text": "Assistant text from part"}]
+        )
+        monitor._load_sqlite_user_text_for_turn = MagicMock(
+            return_value="User text from previous message"
+        )
+
+        message = monitor._extract_turn_message_summary(turn)
+
+        assert message["user"] == "User text from previous message"
+        assert message["assistant"] == "Assistant text from part"
+
+    def test_recent_turn_picker_preview_includes_user_assistant_and_tools(
+        self, tmp_path
+    ):
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        turn = self._make_turn(tmp_path, "ses-1", "turn.json", 1_000)
+        descriptors = monitor._describe_recent_turns(
+            SimpleNamespace(all_sessions=[SimpleNamespace(non_zero_token_files=[turn])])
+        )
+        monitor.console.print = MagicMock()
+
+        monitor._print_recent_turn_picker_table(descriptors, "Recent Turns")
+
+        table = monitor.console.print.call_args.args[0]
+        rendered_rows = [str(column._cells[0]) for column in table.columns]
+        headers = [column.header for column in table.columns]
+        assert "Session" not in headers
+        assert headers[4:9] == [
+            "Input",
+            "Output",
+            "Cache Read",
+            "Cache Write",
+            "Turn Tokens",
+        ]
+        assert "1,000" in rendered_rows
+        assert "100" in rendered_rows
+        assert "200" in rendered_rows
+        assert "50" in rendered_rows
+        assert "1,350" in rendered_rows
+        assert any("U: User request" in cell for cell in rendered_rows)
+        assert any("A: Assistant summary" in cell for cell in rendered_rows)
+        assert any("Tools: bash:completed" in cell for cell in rendered_rows)
+
+    def test_inspect_recent_turns_pauses_live_and_restores_raw_mode(self, tmp_path):
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        live = MagicMock()
+        turn = self._make_turn(tmp_path, "ses-1", "turn.json", 1_000)
+        monitor._stdin_fd = 9
+        monitor._stdin_termios_state = object()
+        monitor._disable_raw_input_mode = MagicMock()
+        monitor._enable_raw_input_mode = MagicMock(return_value=True)
+        monitor._prompt_for_recent_turn_selection = MagicMock(side_effect=[turn, None])
+        monitor._print_turn_detail = MagicMock()
+
+        monitor._inspect_recent_turns_during_live(
+            live, SimpleNamespace(all_sessions=[]), "Recent Turns", True
+        )
+
+        live.stop.assert_called_once()
+        live.start.assert_called_once_with(refresh=True)
+        monitor._disable_raw_input_mode.assert_called_once()
+        monitor._enable_raw_input_mode.assert_called_once()
+        monitor._print_turn_detail.assert_called_once_with(turn)
+        assert monitor._live_status_line is not None
+        assert "Viewed turn turn.json" in monitor._live_status_line
+
+    def test_inspect_recent_turns_can_select_another_turn(self, tmp_path):
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        live = MagicMock()
+        turn_1 = self._make_turn(tmp_path, "ses-1", "turn-1.json", 1_000)
+        turn_2 = self._make_turn(tmp_path, "ses-1", "turn-2.json", 2_000)
+        monitor._prompt_for_recent_turn_selection = MagicMock(
+            side_effect=[turn_1, turn_2, None]
+        )
+        monitor._print_turn_detail = MagicMock()
+
+        monitor._inspect_recent_turns_during_live(
+            live, SimpleNamespace(all_sessions=[]), "Recent Turns", True
+        )
+
+        assert monitor._print_turn_detail.call_args_list[0].args[0] is turn_1
+        assert monitor._print_turn_detail.call_args_list[1].args[0] is turn_2
+
+    def test_poll_live_switch_command_maps_t_to_turns(self, monkeypatch):
+        import os
+        import select
+        import sys
+
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        monitor._stdin_fd = 42
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(
+            select, "select", lambda *args, **kwargs: ([sys.stdin], [], [])
+        )
+        monkeypatch.setattr(os, "read", lambda fd, size: b"t")
+
+        assert monitor._poll_live_switch_command() == "turns"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -11,7 +11,7 @@ from ocmonitor.config import ModelPricing
 
 class TestTokenUsage:
     """Tests for TokenUsage model."""
-    
+
     def test_default_values(self):
         """Test default token usage values."""
         tokens = TokenUsage()
@@ -19,17 +19,17 @@ class TestTokenUsage:
         assert tokens.output == 0
         assert tokens.cache_write == 0
         assert tokens.cache_read == 0
-    
+
     def test_total_calculation(self):
         """Test total token calculation."""
         tokens = TokenUsage(input=1000, output=500, cache_write=200, cache_read=100)
         assert tokens.total == 1800
-    
+
     def test_negative_values_rejected(self):
         """Test that negative token values are rejected."""
         with pytest.raises(ValueError):
             TokenUsage(input=-1)
-    
+
     def test_zero_values_allowed(self):
         """Test that zero values are allowed."""
         tokens = TokenUsage(input=0, output=0, cache_write=0, cache_read=0)
@@ -38,34 +38,34 @@ class TestTokenUsage:
 
 class TestTimeData:
     """Tests for TimeData model."""
-    
+
     def test_duration_calculation(self):
         """Test duration calculation from timestamps."""
         time_data = TimeData(created=1000, completed=5000)
         assert time_data.duration_ms == 4000
-    
+
     def test_duration_none_when_missing_created(self):
         """Test that duration is None when created is missing."""
         time_data = TimeData(completed=5000)
         assert time_data.duration_ms is None
-    
+
     def test_duration_none_when_missing_completed(self):
         """Test that duration is None when completed is missing."""
         time_data = TimeData(created=1000)
         assert time_data.duration_ms is None
-    
+
     def test_created_datetime_conversion(self):
         """Test created timestamp to datetime conversion."""
         # Unix timestamp for 2024-01-01 00:00:00 UTC
         timestamp_ms = 1704067200000
         time_data = TimeData(created=timestamp_ms)
-        
+
         dt = time_data.created_datetime
         assert dt is not None
         assert dt.year == 2024
         assert dt.month == 1
         assert dt.day == 1
-    
+
     def test_datetime_none_when_timestamp_missing(self):
         """Test that datetime is None when timestamp is missing."""
         time_data = TimeData()
@@ -75,48 +75,43 @@ class TestTimeData:
 
 class TestInteractionFile:
     """Tests for InteractionFile model."""
-    
+
     def test_default_values(self):
         """Test default interaction file values."""
         file_path = Path("/tmp/test.json")
         interaction = InteractionFile(file_path=file_path, session_id="ses_test")
-        
+
         assert interaction.model_id == "unknown"
         assert interaction.tokens.total == 0
         assert interaction.time_data is None
         assert interaction.project_path is None
-    
+
     def test_file_path_validation_string(self):
         """Test that string file paths are converted to Path objects."""
-        interaction = InteractionFile(
-            file_path="/tmp/test.json",
-            session_id="ses_test"
-        )
+        interaction = InteractionFile(file_path="/tmp/test.json", session_id="ses_test")
         assert isinstance(interaction.file_path, Path)
-    
+
     def test_file_name_computed(self, tmp_path):
         """Test that file name is computed correctly."""
         test_file = tmp_path / "interaction.json"
         test_file.write_text("{}")
-        
+
         interaction = InteractionFile(file_path=test_file, session_id="ses_test")
         assert interaction.file_name == "interaction.json"
-    
+
     def test_project_name_with_path(self):
         """Test project name extraction from project path."""
         interaction = InteractionFile(
             file_path=Path("/tmp/test.json"),
             session_id="ses_test",
-            project_path="/home/user/myproject"
+            project_path="/home/user/myproject",
         )
         assert interaction.project_name == "myproject"
-    
+
     def test_project_name_unknown(self):
         """Test project name is 'Unknown' when project path is None."""
         interaction = InteractionFile(
-            file_path=Path("/tmp/test.json"),
-            session_id="ses_test",
-            project_path=None
+            file_path=Path("/tmp/test.json"), session_id="ses_test", project_path=None
         )
         assert interaction.project_name == "Unknown"
 
@@ -137,7 +132,9 @@ class TestCalculateCost:
             )
         }
 
-    def _make_interaction(self, tmp_path, raw_data=None, model_id="known-model", **tokens):
+    def _make_interaction(
+        self, tmp_path, raw_data=None, model_id="known-model", **tokens
+    ):
         f = tmp_path / "inter_0001.json"
         f.write_text("{}")
         return InteractionFile(
@@ -153,17 +150,21 @@ class TestCalculateCost:
         interaction = self._make_interaction(
             tmp_path,
             raw_data={"cost": 0.042},
-            input=1000000, output=1000000,
+            input=1000000,
+            output=1000000,
         )
         assert interaction.calculate_cost(pricing_data) == Decimal("0.042")
 
-    def test_stored_cost_used_for_model_not_in_local_pricing(self, tmp_path, pricing_data):
+    def test_stored_cost_used_for_model_not_in_local_pricing(
+        self, tmp_path, pricing_data
+    ):
         """Models not in local pricing (e.g. OpenRouter) use stored cost instead of returning $0.00."""
         interaction = self._make_interaction(
             tmp_path,
             raw_data={"cost": 0.0173},
             model_id="openrouter/anthropic/claude-opus-4.6",
-            input=5000, output=2000,
+            input=5000,
+            output=2000,
         )
         assert interaction.calculate_cost(pricing_data) == Decimal("0.0173")
 
@@ -178,7 +179,9 @@ class TestCalculateCost:
         # 1M input tokens at $1.00/1M = $1.00 (from models.json, not stored cost)
         assert interaction.calculate_cost(pricing_data) == Decimal("1.0")
 
-    def test_falls_back_to_local_pricing_when_no_stored_cost(self, tmp_path, pricing_data):
+    def test_falls_back_to_local_pricing_when_no_stored_cost(
+        self, tmp_path, pricing_data
+    ):
         """When raw_data has no cost, local pricing calculation is used."""
         interaction = self._make_interaction(
             tmp_path,
@@ -193,39 +196,52 @@ class TestCalculateCost:
         interaction = self._make_interaction(
             tmp_path,
             raw_data={"cost": 0.042},
-            input=1000000, output=1000000,
+            input=1000000,
+            output=1000000,
         )
         # With default behavior, returns stored cost
         assert interaction.calculate_cost(pricing_data) == Decimal("0.042")
         # With force_recalculate=True, returns calculated cost from pricing data
         # 1M input + 1M output at $1.00 + $2.00 per M = $3.00
-        assert interaction.calculate_cost(pricing_data, force_recalculate=True) == Decimal("3.0")
+        assert interaction.calculate_cost(
+            pricing_data, force_recalculate=True
+        ) == Decimal("3.0")
 
-    def test_force_recalculate_uses_current_pricing_for_historical_session(self, tmp_path, pricing_data):
+    def test_force_recalculate_uses_current_pricing_for_historical_session(
+        self, tmp_path, pricing_data
+    ):
         """force_recalculate=True recomputes costs using current pricing configuration."""
         interaction = self._make_interaction(
             tmp_path,
             raw_data={"cost": 0.042},
             model_id="known-model",
-            input=500000, output=500000,
+            input=500000,
+            output=500000,
         )
         # Default: uses stored cost
         assert interaction.calculate_cost(pricing_data) == Decimal("0.042")
         # Recalculate: 0.5M input at $1.00/M + 0.5M output at $2.00/M = $1.50
-        assert interaction.calculate_cost(pricing_data, force_recalculate=True) == Decimal("1.5")
+        assert interaction.calculate_cost(
+            pricing_data, force_recalculate=True
+        ) == Decimal("1.5")
 
-    def test_force_recalculate_returns_zero_for_unknown_model_without_pricing(self, tmp_path, pricing_data):
+    def test_force_recalculate_returns_zero_for_unknown_model_without_pricing(
+        self, tmp_path, pricing_data
+    ):
         """Unknown models with no pricing return $0.00 when force_recalculate=True."""
         interaction = self._make_interaction(
             tmp_path,
             raw_data={"cost": 0.042},
             model_id="completely-unknown-model-xyz",
-            input=1000000, output=1000000,
+            input=1000000,
+            output=1000000,
         )
         # Default: uses stored cost
         assert interaction.calculate_cost(pricing_data) == Decimal("0.042")
         # Recalculate: no pricing found, returns $0.00
-        assert interaction.calculate_cost(pricing_data, force_recalculate=True) == Decimal("0.0")
+        assert interaction.calculate_cost(
+            pricing_data, force_recalculate=True
+        ) == Decimal("0.0")
 
 
 class TestSessionData:
@@ -243,107 +259,107 @@ class TestSessionData:
                 sessionQuota=Decimal("5.0"),
             )
         }
-    
+
     def test_session_data_creation(self, tmp_path):
         """Test basic session data creation."""
         session_path = tmp_path / "ses_test"
         session_path.mkdir()
-        
+
         interaction = InteractionFile(
             file_path=session_path / "inter_0001.json",
             session_id="ses_test",
             model_id="test-model",
-            tokens=TokenUsage(input=1000, output=500)
+            tokens=TokenUsage(input=1000, output=500),
         )
-        
+
         session = SessionData(
             session_id="ses_test",
             session_path=session_path,
             files=[interaction],
-            session_title="Test Session"
+            session_title="Test Session",
         )
-        
+
         assert session.session_id == "ses_test"
         assert session.session_title == "Test Session"
         assert len(session.files) == 1
-    
+
     def test_total_tokens_aggregation(self, tmp_path):
         """Test that total tokens are aggregated across all interactions."""
         session_path = tmp_path / "ses_test"
         session_path.mkdir()
-        
+
         interaction1 = InteractionFile(
             file_path=session_path / "inter_0001.json",
             session_id="ses_test",
-            tokens=TokenUsage(input=1000, output=500, cache_write=200, cache_read=100)
+            tokens=TokenUsage(input=1000, output=500, cache_write=200, cache_read=100),
         )
-        
+
         interaction2 = InteractionFile(
             file_path=session_path / "inter_0002.json",
             session_id="ses_test",
-            tokens=TokenUsage(input=500, output=300, cache_write=100, cache_read=50)
+            tokens=TokenUsage(input=500, output=300, cache_write=100, cache_read=50),
         )
-        
+
         session = SessionData(
             session_id="ses_test",
             session_path=session_path,
-            files=[interaction1, interaction2]
+            files=[interaction1, interaction2],
         )
-        
+
         assert session.total_tokens.input == 1500
         assert session.total_tokens.output == 800
         assert session.total_tokens.cache_write == 300
         assert session.total_tokens.cache_read == 150
         assert session.total_tokens.total == 2750
-    
+
     def test_session_path_validation_string(self, tmp_path):
         """Test that string session paths are converted to Path objects."""
         session_path = tmp_path / "ses_test"
         session_path.mkdir()
-        
+
         session = SessionData(
-            session_id="ses_test",
-            session_path=str(session_path),
-            files=[]
+            session_id="ses_test", session_path=str(session_path), files=[]
         )
-        
+
         assert isinstance(session.session_path, Path)
-    
+
     def test_models_used_computed(self, tmp_path):
         """Test that models_used returns unique model IDs."""
         session_path = tmp_path / "ses_test"
         session_path.mkdir()
-        
+
         interaction1 = InteractionFile(
             file_path=session_path / "inter_0001.json",
             session_id="ses_test",
-            model_id="model-a"
+            model_id="model-a",
         )
-        
+
         interaction2 = InteractionFile(
             file_path=session_path / "inter_0002.json",
             session_id="ses_test",
-            model_id="model-b"
+            model_id="model-b",
         )
-        
+
         interaction3 = InteractionFile(
             file_path=session_path / "inter_0003.json",
             session_id="ses_test",
-            model_id="model-a"  # Duplicate
+            model_id="model-a",  # Duplicate
         )
-        
+
         session = SessionData(
             session_id="ses_test",
             session_path=session_path,
-            files=[interaction1, interaction2, interaction3]
+            files=[interaction1, interaction2, interaction3],
         )
-        
+
         models = session.models_used
         assert "model-a" in models
         assert "model-b" in models
         assert len(models) == 2  # Should only have 2 unique models
 
-    def test_session_total_cost_respects_force_recalculate(self, tmp_path, pricing_data):
+    def test_session_total_cost_respects_force_recalculate(
+        self, tmp_path, pricing_data
+    ):
         """Session total cost changes when force_recalculate=True for stored cost."""
         session_path = tmp_path / "ses_test"
         session_path.mkdir()
@@ -373,9 +389,13 @@ class TestSessionData:
         # Default: uses stored costs (0.05 + 0.10 = 0.15)
         assert session.calculate_total_cost(pricing_data) == Decimal("0.15")
         # Recalculate: uses pricing data (1M input at $1/M + 1M output at $2/M = 3.0)
-        assert session.calculate_total_cost(pricing_data, force_recalculate=True) == Decimal("3.0")
+        assert session.calculate_total_cost(
+            pricing_data, force_recalculate=True
+        ) == Decimal("3.0")
 
-    def test_session_model_breakdown_respects_force_recalculate(self, tmp_path, pricing_data):
+    def test_session_model_breakdown_respects_force_recalculate(
+        self, tmp_path, pricing_data
+    ):
         """Per-model cost totals in session model breakdown change with force_recalculate=True."""
         session_path = tmp_path / "ses_test"
         session_path.mkdir()
@@ -407,8 +427,51 @@ class TestSessionData:
         assert breakdown["known-model"]["cost"] == Decimal("0.15")
 
         # Recalculate: uses pricing data
-        breakdown_recalc = session.get_model_breakdown(pricing_data, force_recalculate=True)
+        breakdown_recalc = session.get_model_breakdown(
+            pricing_data, force_recalculate=True
+        )
         assert breakdown_recalc["known-model"]["cost"] == Decimal("3.0")
+
+    def test_agent_model_breakdown_splits_same_model_by_agent(self, tmp_path):
+        """Live dashboard helper splits one shared model into agent-specific groups."""
+        session_path = tmp_path / "ses_test"
+        session_path.mkdir()
+
+        build_file = InteractionFile(
+            file_path=session_path / "inter_build.json",
+            session_id="ses_test",
+            model_id="shared-model",
+            agent="build",
+            tokens=TokenUsage(input=100, output=50, cache_read=200, cache_write=25),
+            raw_data={"cost": 0.10},
+        )
+        lite_file = InteractionFile(
+            file_path=session_path / "inter_lite.json",
+            session_id="ses_test",
+            model_id="shared-model",
+            agent="lite-worker",
+            tokens=TokenUsage(input=300, output=75, cache_read=400, cache_write=10),
+            raw_data={"cost": 0.20},
+        )
+        session = SessionData(
+            session_id="ses_test",
+            session_path=session_path,
+            files=[build_file, lite_file],
+        )
+
+        regular_breakdown = session.get_model_breakdown({})
+        assert list(regular_breakdown) == ["shared-model"]
+        assert regular_breakdown["shared-model"]["tokens"].total == 1160
+
+        agent_breakdown = session.get_agent_model_breakdown({})
+        assert set(agent_breakdown) == {
+            "build::shared-model",
+            "lite-worker::shared-model",
+        }
+        assert agent_breakdown["build::shared-model"]["agent"] == "build"
+        assert agent_breakdown["build::shared-model"]["tokens"].total == 375
+        assert agent_breakdown["lite-worker::shared-model"]["agent"] == "lite-worker"
+        assert agent_breakdown["lite-worker::shared-model"]["tokens"].total == 785
 
 
 class TestAnalyticsForceRecalculate:
@@ -427,7 +490,14 @@ class TestAnalyticsForceRecalculate:
             )
         }
 
-    def _make_interaction(self, tmp_path, session_id="ses_test", raw_data=None, model_id="known-model", **tokens):
+    def _make_interaction(
+        self,
+        tmp_path,
+        session_id="ses_test",
+        raw_data=None,
+        model_id="known-model",
+        **tokens,
+    ):
         f = tmp_path / f"{session_id}_inter.json"
         f.write_text("{}")
         return InteractionFile(
@@ -438,7 +508,14 @@ class TestAnalyticsForceRecalculate:
             raw_data=raw_data or {},
         )
 
-    def _make_session(self, tmp_path, session_id="ses_test", raw_data=None, model_id="known-model", **tokens):
+    def _make_session(
+        self,
+        tmp_path,
+        session_id="ses_test",
+        raw_data=None,
+        model_id="known-model",
+        **tokens,
+    ):
         session_path = tmp_path / session_id
         session_path.mkdir(exist_ok=True)
         interaction = self._make_interaction(
@@ -450,7 +527,9 @@ class TestAnalyticsForceRecalculate:
             files=[interaction],
         )
 
-    def test_daily_usage_total_cost_respects_force_recalculate(self, tmp_path, pricing_data):
+    def test_daily_usage_total_cost_respects_force_recalculate(
+        self, tmp_path, pricing_data
+    ):
         """DailyUsage.calculate_total_cost changes with force_recalculate=True."""
         from ocmonitor.models.analytics import DailyUsage
         from datetime import date
@@ -468,9 +547,13 @@ class TestAnalyticsForceRecalculate:
         # Default: uses stored cost
         assert daily.calculate_total_cost(pricing_data) == Decimal("0.50")
         # Recalculate: 1M input at $1/M + 1M output at $2/M = $3.00
-        assert daily.calculate_total_cost(pricing_data, force_recalculate=True) == Decimal("3.0")
+        assert daily.calculate_total_cost(
+            pricing_data, force_recalculate=True
+        ) == Decimal("3.0")
 
-    def test_weekly_usage_total_cost_respects_force_recalculate(self, tmp_path, pricing_data):
+    def test_weekly_usage_total_cost_respects_force_recalculate(
+        self, tmp_path, pricing_data
+    ):
         """WeeklyUsage.calculate_total_cost changes with force_recalculate=True."""
         from ocmonitor.models.analytics import DailyUsage, WeeklyUsage
         from datetime import date
@@ -485,16 +568,23 @@ class TestAnalyticsForceRecalculate:
 
         daily = DailyUsage(date=date(2026, 4, 7), sessions=[session])
         weekly = WeeklyUsage(
-            year=2026, week=15, start_date=date(2026, 4, 6), end_date=date(2026, 4, 12),
+            year=2026,
+            week=15,
+            start_date=date(2026, 4, 6),
+            end_date=date(2026, 4, 12),
             daily_usage=[daily],
         )
 
         # Default: uses stored cost
         assert weekly.calculate_total_cost(pricing_data) == Decimal("0.50")
         # Recalculate: $3.00
-        assert weekly.calculate_total_cost(pricing_data, force_recalculate=True) == Decimal("3.0")
+        assert weekly.calculate_total_cost(
+            pricing_data, force_recalculate=True
+        ) == Decimal("3.0")
 
-    def test_monthly_usage_total_cost_respects_force_recalculate(self, tmp_path, pricing_data):
+    def test_monthly_usage_total_cost_respects_force_recalculate(
+        self, tmp_path, pricing_data
+    ):
         """MonthlyUsage.calculate_total_cost changes with force_recalculate=True."""
         from ocmonitor.models.analytics import DailyUsage, WeeklyUsage, MonthlyUsage
         from datetime import date
@@ -509,7 +599,10 @@ class TestAnalyticsForceRecalculate:
 
         daily = DailyUsage(date=date(2026, 4, 7), sessions=[session])
         weekly = WeeklyUsage(
-            year=2026, week=15, start_date=date(2026, 4, 6), end_date=date(2026, 4, 12),
+            year=2026,
+            week=15,
+            start_date=date(2026, 4, 6),
+            end_date=date(2026, 4, 12),
             daily_usage=[daily],
         )
         monthly = MonthlyUsage(year=2026, month=4, weekly_usage=[weekly])
@@ -517,9 +610,13 @@ class TestAnalyticsForceRecalculate:
         # Default: uses stored cost
         assert monthly.calculate_total_cost(pricing_data) == Decimal("0.50")
         # Recalculate: $3.00
-        assert monthly.calculate_total_cost(pricing_data, force_recalculate=True) == Decimal("3.0")
+        assert monthly.calculate_total_cost(
+            pricing_data, force_recalculate=True
+        ) == Decimal("3.0")
 
-    def test_create_model_breakdown_respects_force_recalculate(self, tmp_path, pricing_data):
+    def test_create_model_breakdown_respects_force_recalculate(
+        self, tmp_path, pricing_data
+    ):
         """TimeframeAnalyzer.create_model_breakdown changes with force_recalculate=True."""
         from ocmonitor.models.analytics import TimeframeAnalyzer
 
@@ -541,7 +638,9 @@ class TestAnalyticsForceRecalculate:
         )
         assert report_recalc.total_cost == Decimal("3.0")
 
-    def test_create_project_breakdown_respects_force_recalculate(self, tmp_path, pricing_data):
+    def test_create_project_breakdown_respects_force_recalculate(
+        self, tmp_path, pricing_data
+    ):
         """TimeframeAnalyzer.create_project_breakdown changes with force_recalculate=True."""
         from ocmonitor.models.analytics import TimeframeAnalyzer
 
@@ -580,7 +679,14 @@ class TestWorkflowForceRecalculate:
             )
         }
 
-    def _make_session(self, tmp_path, session_id="ses_test", raw_data=None, model_id="known-model", **tokens):
+    def _make_session(
+        self,
+        tmp_path,
+        session_id="ses_test",
+        raw_data=None,
+        model_id="known-model",
+        **tokens,
+    ):
         session_path = tmp_path / session_id
         session_path.mkdir(exist_ok=True)
         f = tmp_path / f"{session_id}_inter.json"
@@ -598,7 +704,9 @@ class TestWorkflowForceRecalculate:
             files=[interaction],
         )
 
-    def test_workflow_total_cost_respects_force_recalculate(self, tmp_path, pricing_data):
+    def test_workflow_total_cost_respects_force_recalculate(
+        self, tmp_path, pricing_data
+    ):
         """SessionWorkflow.calculate_total_cost changes with force_recalculate=True."""
         from ocmonitor.models.workflow import SessionWorkflow
 
@@ -629,13 +737,17 @@ class TestWorkflowForceRecalculate:
 
         # Recalculate: (1M input + 1M output at $3/M) + (0.5M input + 0.5M output at $3/M)
         # = $3.00 + $1.50 = $4.50
-        assert workflow.calculate_total_cost(pricing_data, force_recalculate=True) == Decimal("4.5")
+        assert workflow.calculate_total_cost(
+            pricing_data, force_recalculate=True
+        ) == Decimal("4.5")
 
 
 class TestReportGeneratorModelBreakdown:
     """Tests for ReportGenerator._get_model_breakdown_for_sessions provider-aware grouping."""
 
-    def _make_file(self, tmp_path, session_id, name, model_id, provider_id=None, **tokens):
+    def _make_file(
+        self, tmp_path, session_id, name, model_id, provider_id=None, **tokens
+    ):
         f = tmp_path / f"{name}.json"
         f.write_text("{}")
         return InteractionFile(
@@ -653,12 +765,22 @@ class TestReportGeneratorModelBreakdown:
         from ocmonitor.services.report_generator import ReportGenerator
 
         file_a = self._make_file(
-            tmp_path, "ses1", "file_a", model_id="claude-sonnet", provider_id="prov-a",
-            input=100, output=50,
+            tmp_path,
+            "ses1",
+            "file_a",
+            model_id="claude-sonnet",
+            provider_id="prov-a",
+            input=100,
+            output=50,
         )
         file_b = self._make_file(
-            tmp_path, "ses1", "file_b", model_id="claude-sonnet", provider_id="prov-b",
-            input=200, output=80,
+            tmp_path,
+            "ses1",
+            "file_b",
+            model_id="claude-sonnet",
+            provider_id="prov-b",
+            input=200,
+            output=80,
         )
 
         session = SessionData(
@@ -676,7 +798,9 @@ class TestReportGeneratorModelBreakdown:
         models_in_results = {r["model"] for r in results}
         assert "prov-a/claude-sonnet" in models_in_results, "prov-a entry missing"
         assert "prov-b/claude-sonnet" in models_in_results, "prov-b entry missing"
-        assert len(results) == 2, f"Expected 2 rows, got {len(results)}: {models_in_results}"
+        assert len(results) == 2, (
+            f"Expected 2 rows, got {len(results)}: {models_in_results}"
+        )
 
     def test_same_provider_same_model_id_are_merged(self, tmp_path):
         """Two files with the same provider+model_id must be aggregated into one row."""
@@ -684,12 +808,22 @@ class TestReportGeneratorModelBreakdown:
         from ocmonitor.services.report_generator import ReportGenerator
 
         file_a = self._make_file(
-            tmp_path, "ses1", "file_c", model_id="gpt-4o", provider_id="openai",
-            input=100, output=50,
+            tmp_path,
+            "ses1",
+            "file_c",
+            model_id="gpt-4o",
+            provider_id="openai",
+            input=100,
+            output=50,
         )
         file_b = self._make_file(
-            tmp_path, "ses1", "file_d", model_id="gpt-4o", provider_id="openai",
-            input=200, output=80,
+            tmp_path,
+            "ses1",
+            "file_d",
+            model_id="gpt-4o",
+            provider_id="openai",
+            input=200,
+            output=80,
         )
 
         session = SessionData(
@@ -726,7 +860,9 @@ class TestSessionAnalyzerProviderAwareRegressions:
             raw_data={},
         )
 
-    def test_filter_sessions_by_model_matches_bare_name_against_provider_model(self, tmp_path):
+    def test_filter_sessions_by_model_matches_bare_name_against_provider_model(
+        self, tmp_path
+    ):
         """Bare model filter should match provider/model display values for backward compatibility."""
         from ocmonitor.services.session_analyzer import SessionAnalyzer
 
@@ -749,7 +885,9 @@ class TestSessionAnalyzerProviderAwareRegressions:
 
         assert len(result) == 1
 
-    def test_validate_session_health_no_false_unknown_warning_for_bare_model(self, tmp_path):
+    def test_validate_session_health_no_false_unknown_warning_for_bare_model(
+        self, tmp_path
+    ):
         """Bare model should not be flagged unknown when pricing exists under provider/model key."""
         from ocmonitor.services.session_analyzer import SessionAnalyzer
 
@@ -782,7 +920,9 @@ class TestSessionAnalyzerProviderAwareRegressions:
         result = analyzer.validate_session_health(session)
 
         unknown_warnings = [
-            w for w in result.get("warnings", []) if "Unknown models with no pricing" in w
+            w
+            for w in result.get("warnings", [])
+            if "Unknown models with no pricing" in w
         ]
         assert unknown_warnings == []
 
@@ -899,7 +1039,9 @@ class TestSessionDataProviderAwareModelFields:
 
         assert session.models_used == ["prov-a/model-x"]
 
-    def test_models_used_keeps_same_model_under_different_providers_distinct(self, tmp_path):
+    def test_models_used_keeps_same_model_under_different_providers_distinct(
+        self, tmp_path
+    ):
         """Same bare model under different providers remains distinct."""
         file_a = self._make_file(
             tmp_path, "a", model_id="model-x", provider_id="prov-a"
@@ -985,7 +1127,9 @@ class TestInteractionDateAttribution:
             time_data=TimeData(created=int(created_dt.timestamp() * 1000)),
         )
 
-    def test_daily_breakdown_splits_one_session_across_interaction_dates(self, tmp_path):
+    def test_daily_breakdown_splits_one_session_across_interaction_dates(
+        self, tmp_path
+    ):
         """Daily usage should split a multi-day session by interaction date."""
         from ocmonitor.models.analytics import TimeframeAnalyzer
 
@@ -1007,7 +1151,9 @@ class TestInteractionDateAttribution:
         assert [d.total_interactions for d in daily] == [1, 1]
         assert [d.total_tokens.input for d in daily] == [100, 200]
 
-    def test_weekly_and_monthly_total_sessions_are_unique_across_split_days(self, tmp_path):
+    def test_weekly_and_monthly_total_sessions_are_unique_across_split_days(
+        self, tmp_path
+    ):
         """Weekly and monthly session totals should not double count a split session."""
         from ocmonitor.models.analytics import TimeframeAnalyzer
 
@@ -1032,7 +1178,9 @@ class TestInteractionDateAttribution:
         assert len(monthly) == 1
         assert monthly[0].total_sessions == 1
 
-    def test_model_breakdown_filters_by_interaction_date_not_session_start(self, tmp_path, pricing_data):
+    def test_model_breakdown_filters_by_interaction_date_not_session_start(
+        self, tmp_path, pricing_data
+    ):
         """Model breakdown should include only interactions in the date window."""
         from ocmonitor.models.analytics import TimeframeAnalyzer
 
@@ -1059,7 +1207,9 @@ class TestInteractionDateAttribution:
         assert report.model_stats[0].total_interactions == 1
         assert report.model_stats[0].total_tokens.input == 700
 
-    def test_project_breakdown_filters_by_interaction_date_not_session_start(self, tmp_path, pricing_data):
+    def test_project_breakdown_filters_by_interaction_date_not_session_start(
+        self, tmp_path, pricing_data
+    ):
         """Project breakdown should count only in-window interactions and cost."""
         from ocmonitor.models.analytics import TimeframeAnalyzer
 
@@ -1087,7 +1237,9 @@ class TestInteractionDateAttribution:
         assert report.project_stats[0].total_tokens.input == 700
         assert report.project_stats[0].total_cost == Decimal("0.0007")
 
-    def test_project_breakdown_buckets_filtered_files_by_file_project(self, tmp_path, pricing_data):
+    def test_project_breakdown_buckets_filtered_files_by_file_project(
+        self, tmp_path, pricing_data
+    ):
         """Project breakdown should bucket filtered interactions by each file's project path."""
         from ocmonitor.models.analytics import TimeframeAnalyzer
 
@@ -1120,7 +1272,9 @@ class TestInteractionDateAttribution:
         assert by_project["project-b"].total_interactions == 1
         assert by_project["project-b"].total_sessions == 1
 
-    def test_model_last_used_does_not_fall_back_to_unfiltered_session_end(self, tmp_path, pricing_data):
+    def test_model_last_used_does_not_fall_back_to_unfiltered_session_end(
+        self, tmp_path, pricing_data
+    ):
         """Model last_used should not leak end time from unrelated filtered files."""
         from ocmonitor.models.analytics import TimeframeAnalyzer
 
@@ -1153,7 +1307,9 @@ class TestInteractionDateAttribution:
         assert by_model["known-model"].last_used == session.start_time
         assert by_model["known-model"].last_used != session.end_time
 
-    def test_model_times_fall_back_to_session_start_when_file_timestamps_missing(self, tmp_path, pricing_data):
+    def test_model_times_fall_back_to_session_start_when_file_timestamps_missing(
+        self, tmp_path, pricing_data
+    ):
         """Model first/last used should fall back to session start for timestamp-less files."""
         from ocmonitor.models.analytics import TimeframeAnalyzer
 
@@ -1194,7 +1350,9 @@ class TestInteractionDateAttribution:
         assert by_model["known-model"].first_used == session.start_time
         assert by_model["known-model"].last_used == session.start_time
 
-    def test_project_last_activity_does_not_fall_back_to_unfiltered_session_end(self, tmp_path, pricing_data):
+    def test_project_last_activity_does_not_fall_back_to_unfiltered_session_end(
+        self, tmp_path, pricing_data
+    ):
         """Project last_activity should not leak end time from other project files."""
         from ocmonitor.models.analytics import TimeframeAnalyzer
 
@@ -1228,7 +1386,9 @@ class TestInteractionDateAttribution:
         assert by_project["project-a"].last_activity == session.start_time
         assert by_project["project-a"].last_activity != session.end_time
 
-    def test_project_times_fall_back_to_session_start_when_file_timestamps_missing(self, tmp_path, pricing_data):
+    def test_project_times_fall_back_to_session_start_when_file_timestamps_missing(
+        self, tmp_path, pricing_data
+    ):
         """Project first/last activity should fall back to session start for timestamp-less files."""
         from ocmonitor.models.analytics import TimeframeAnalyzer
 
@@ -1297,7 +1457,9 @@ class TestInteractionDateAttribution:
         assert len(filtered[0].files) == 1
         assert filtered[0].files[0].tokens.input == 700
 
-    def test_filter_sessions_by_date_falls_back_to_session_start_for_missing_timestamps(self, tmp_path):
+    def test_filter_sessions_by_date_falls_back_to_session_start_for_missing_timestamps(
+        self, tmp_path
+    ):
         """Date filtering should fall back to session start when interaction timestamp is missing."""
         from ocmonitor.services.session_analyzer import SessionAnalyzer
 

--- a/tests/unit/test_sqlite_active_workflows.py
+++ b/tests/unit/test_sqlite_active_workflows.py
@@ -115,3 +115,97 @@ def test_get_all_active_workflows_orders_by_latest_parent_activity(tmp_path: Pat
     )
 
     assert [w["workflow_id"] for w in workflows[:2]] == ["older-parent", "newer-parent"]
+
+
+def test_get_recent_workflows(tmp_path: Path):
+    db_path = tmp_path / "opencode.db"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    _create_base_schema(conn)
+
+    now_ms = int(time.time() * 1000)
+
+    conn.execute(
+        "INSERT INTO project (id, worktree, name) VALUES (?, ?, ?)",
+        ("proj", "/tmp/project", "project"),
+    )
+
+    # Insert 6 parent sessions
+    for i in range(1, 7):
+        conn.execute(
+            "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
+            (f"parent-{i}", "proj", None, f"Parent {i}", now_ms - i * 1000, now_ms - i * 1000),
+        )
+        # Parent 5 has NO messages (empty session)
+        if i != 5:
+            conn.execute(
+                "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+                (f"msg-{i}", f"parent-{i}", now_ms - i * 1000, now_ms - i * 1000, _assistant_message()),
+            )
+
+    conn.commit()
+    conn.close()
+
+    # Get recent workflows with a limit of 3
+    # Expected: should get parent-1, parent-2, parent-3 (ordered DESC by time_created, skipping parent-5)
+    workflows = SQLiteProcessor.get_recent_workflows(db_path=db_path, limit=3)
+
+    assert len(workflows) == 3
+    assert [w["workflow_id"] for w in workflows] == ["parent-1", "parent-2", "parent-3"]
+
+    # Get recent workflows with a limit of 10
+    # Expected: should get parent-1, parent-2, parent-3, parent-4, parent-6 (skipping parent-5)
+    all_workflows = SQLiteProcessor.get_recent_workflows(db_path=db_path, limit=10)
+    assert len(all_workflows) == 5
+    assert [w["workflow_id"] for w in all_workflows] == ["parent-1", "parent-2", "parent-3", "parent-4", "parent-6"]
+
+
+def test_get_workflow_by_id(tmp_path: Path):
+    db_path = tmp_path / "opencode.db"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    _create_base_schema(conn)
+
+    now_ms = int(time.time() * 1000)
+
+    conn.execute(
+        "INSERT INTO project (id, worktree, name) VALUES (?, ?, ?)",
+        ("proj", "/tmp/project", "project"),
+    )
+
+    # Insert parent session and a sub-agent session
+    conn.execute(
+        "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
+        ("parent-id", "proj", None, "Parent Title", now_ms, now_ms),
+    )
+    conn.execute(
+        "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+        ("msg-1", "parent-id", now_ms, now_ms, _assistant_message()),
+    )
+
+    conn.execute(
+        "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
+        ("sub-id", "proj", "parent-id", "Sub Title", now_ms + 1000, now_ms + 1000),
+    )
+    conn.execute(
+        "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+        ("msg-2", "sub-id", now_ms + 1000, now_ms + 1000, _assistant_message()),
+    )
+
+    conn.commit()
+    conn.close()
+
+    # Resolve by parent workflow ID
+    wf = SQLiteProcessor.get_workflow_by_id("parent-id", db_path=db_path)
+    assert wf is not None
+    assert wf["workflow_id"] == "parent-id"
+    assert len(wf["all_sessions"]) == 2
+
+    # Resolve by sub-agent ID
+    wf_sub = SQLiteProcessor.get_workflow_by_id("sub-id", db_path=db_path)
+    assert wf_sub is not None
+    assert wf_sub["workflow_id"] == "parent-id"  # Maps back to parent's workflow
+
+    # Resolve non-existent ID
+    wf_none = SQLiteProcessor.get_workflow_by_id("non-existent", db_path=db_path)
+    assert wf_none is None

--- a/tests/unit/test_sqlite_tool_usage.py
+++ b/tests/unit/test_sqlite_tool_usage.py
@@ -21,7 +21,7 @@ class TestLoadToolUsageForSessions:
         db_path = tmp_path / "test_opencode.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
+
         # Create tables
         conn.execute("""
             CREATE TABLE session (
@@ -33,7 +33,7 @@ class TestLoadToolUsageForSessions:
                 time_updated INTEGER NOT NULL
             )
         """)
-        
+
         conn.execute("""
             CREATE TABLE part (
                 id TEXT PRIMARY KEY,
@@ -44,90 +44,77 @@ class TestLoadToolUsageForSessions:
                 data TEXT NOT NULL
             )
         """)
-        
+
         # Insert test sessions
         conn.execute(
             "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_test1", "proj_1", None, "Test Session 1", 1000, 2000)
+            ("ses_test1", "proj_1", None, "Test Session 1", 1000, 2000),
         )
         conn.execute(
             "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_test2", "proj_1", None, "Test Session 2", 3000, 4000)
+            ("ses_test2", "proj_1", None, "Test Session 2", 3000, 4000),
         )
-        
+
         # Insert tool parts for session 1
         # bash: 3 completed, 1 error
         for i, status in enumerate(["completed", "completed", "completed", "error"]):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "bash",
-                "state": {"status": status}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "bash", "state": {"status": status}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_bash_{i}", "msg_1", "ses_test1", 1000 + i, 1000 + i, data)
+                (f"prt_bash_{i}", "msg_1", "ses_test1", 1000 + i, 1000 + i, data),
             )
-        
+
         # read: 2 completed
         for i in range(2):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "read",
-                "state": {"status": "completed"}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "read", "state": {"status": "completed"}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_read_{i}", "msg_1", "ses_test1", 2000 + i, 2000 + i, data)
+                (f"prt_read_{i}", "msg_1", "ses_test1", 2000 + i, 2000 + i, data),
             )
-        
+
         # edit: 1 completed, 2 error
         for i, status in enumerate(["completed", "error", "error"]):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "edit",
-                "state": {"status": status}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "edit", "state": {"status": status}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_edit_{i}", "msg_1", "ses_test1", 3000 + i, 3000 + i, data)
+                (f"prt_edit_{i}", "msg_1", "ses_test1", 3000 + i, 3000 + i, data),
             )
-        
+
         # Insert tool parts for session 2
         # bash: 1 completed
-        data = json.dumps({
-            "type": "tool",
-            "tool": "bash",
-            "state": {"status": "completed"}
-        })
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "completed"}}
+        )
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_bash_s2", "msg_2", "ses_test2", 3000, 3000, data)
+            ("prt_bash_s2", "msg_2", "ses_test2", 3000, 3000, data),
         )
-        
+
         # Insert non-tool parts (should be ignored)
-        data = json.dumps({
-            "type": "text",
-            "text": "Some text"
-        })
+        data = json.dumps({"type": "text", "text": "Some text"})
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_text", "msg_1", "ses_test1", 4000, 4000, data)
+            ("prt_text", "msg_1", "ses_test1", 4000, 4000, data),
         )
-        
+
         # Insert running tool (should be ignored)
-        data = json.dumps({
-            "type": "tool",
-            "tool": "bash",
-            "state": {"status": "running"}
-        })
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "running"}}
+        )
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_running", "msg_1", "ses_test1", 5000, 5000, data)
+            ("prt_running", "msg_1", "ses_test1", 5000, 5000, data),
         )
-        
+
         conn.commit()
         conn.close()
-        
+
         return db_path
 
     def test_load_tool_usage_aggregates_correctly(self, temp_db: Path):
@@ -135,23 +122,23 @@ class TestLoadToolUsageForSessions:
         stats = SQLiteProcessor.load_tool_usage_for_sessions(
             ["ses_test1", "ses_test2"], temp_db
         )
-        
+
         assert len(stats) == 3
-        
+
         # bash should be first (most calls: 4 completed from ses_test1 + 1 completed from ses_test2 + 1 error = 5 total)
         assert stats[0].tool_name == "bash"
         assert stats[0].total_calls == 5  # 4 completed + 1 error (running is excluded)
         assert stats[0].success_count == 4  # 3 from ses_test1 + 1 from ses_test2
         assert stats[0].failure_count == 1
         assert stats[0].success_rate == 80.0
-        
+
         # edit: 1 completed + 2 error = 3 total
         edit_stat = next(s for s in stats if s.tool_name == "edit")
         assert edit_stat.total_calls == 3
         assert edit_stat.success_count == 1
         assert edit_stat.failure_count == 2
         assert edit_stat.success_rate == pytest.approx(33.33, rel=0.01)
-        
+
         # read: 2 completed
         read_stat = next(s for s in stats if s.tool_name == "read")
         assert read_stat.total_calls == 2
@@ -161,10 +148,8 @@ class TestLoadToolUsageForSessions:
 
     def test_load_tool_usage_excludes_running_status(self, temp_db: Path):
         """Test that running status is excluded from stats."""
-        stats = SQLiteProcessor.load_tool_usage_for_sessions(
-            ["ses_test1"], temp_db
-        )
-        
+        stats = SQLiteProcessor.load_tool_usage_for_sessions(["ses_test1"], temp_db)
+
         # The running bash command should be excluded
         # ses_test1 has: 3 bash completed, 1 bash error, 1 bash running
         # So bash should have 4 total (3 completed + 1 error), not 5
@@ -185,7 +170,7 @@ class TestLoadToolUsageForSessions:
 
     def test_load_tool_usage_missing_db_path(self, tmp_path: Path):
         """Test that missing database path returns empty list."""
-        with patch.object(SQLiteProcessor, 'find_database_path', return_value=None):
+        with patch.object(SQLiteProcessor, "find_database_path", return_value=None):
             stats = SQLiteProcessor.load_tool_usage_for_sessions(["ses_test"])
             assert stats == []
 
@@ -194,7 +179,7 @@ class TestLoadToolUsageForSessions:
         stats = SQLiteProcessor.load_tool_usage_for_sessions(
             ["ses_test1", "ses_test2"], temp_db
         )
-        
+
         # Verify sorted by total_calls descending
         for i in range(len(stats) - 1):
             assert stats[i].total_calls >= stats[i + 1].total_calls
@@ -204,7 +189,7 @@ class TestLoadToolUsageForSessions:
         db_path = tmp_path / "test_malformed.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
+
         # Create tables
         conn.execute("""
             CREATE TABLE session (
@@ -216,7 +201,7 @@ class TestLoadToolUsageForSessions:
                 time_updated INTEGER NOT NULL
             )
         """)
-        
+
         conn.execute("""
             CREATE TABLE part (
                 id TEXT PRIMARY KEY,
@@ -227,44 +212,47 @@ class TestLoadToolUsageForSessions:
                 data TEXT NOT NULL
             )
         """)
-        
+
         # Insert test session
         conn.execute(
             "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_malformed", "proj_1", None, "Malformed Test", 1000, 2000)
+            ("ses_malformed", "proj_1", None, "Malformed Test", 1000, 2000),
         )
-        
+
         # Insert valid tool
-        data = json.dumps({
-            "type": "tool",
-            "tool": "bash",
-            "state": {"status": "completed"}
-        })
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "completed"}}
+        )
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_valid", "msg_1", "ses_malformed", 1000, 1000, data)
+            ("prt_valid", "msg_1", "ses_malformed", 1000, 1000, data),
         )
-        
+
         # Insert malformed JSON (should be ignored without error)
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_malformed", "msg_1", "ses_malformed", 2000, 2000, "{not valid json}")
+            ("prt_malformed", "msg_1", "ses_malformed", 2000, 2000, "{not valid json}"),
         )
-        
+
         # Insert malformed JSON that looks like tool (should be ignored)
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_malformed2", "msg_1", "ses_malformed", 3000, 3000, '{"type": "tool", "tool": "edit"')
+            (
+                "prt_malformed2",
+                "msg_1",
+                "ses_malformed",
+                3000,
+                3000,
+                '{"type": "tool", "tool": "edit"',
+            ),
         )
-        
+
         conn.commit()
         conn.close()
-        
+
         # Should not raise and should only count valid tool
-        stats = SQLiteProcessor.load_tool_usage_for_sessions(
-            ["ses_malformed"], db_path
-        )
-        
+        stats = SQLiteProcessor.load_tool_usage_for_sessions(["ses_malformed"], db_path)
+
         assert len(stats) == 1
         assert stats[0].tool_name == "bash"
         assert stats[0].total_calls == 1
@@ -274,7 +262,7 @@ class TestLoadToolUsageForSessions:
         db_path = tmp_path / "test_null_tool.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
+
         # Create tables
         conn.execute("""
             CREATE TABLE session (
@@ -286,7 +274,7 @@ class TestLoadToolUsageForSessions:
                 time_updated INTEGER NOT NULL
             )
         """)
-        
+
         conn.execute("""
             CREATE TABLE part (
                 id TEXT PRIMARY KEY,
@@ -297,42 +285,35 @@ class TestLoadToolUsageForSessions:
                 data TEXT NOT NULL
             )
         """)
-        
+
         # Insert test session
         conn.execute(
             "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_null", "proj_1", None, "Null Tool Test", 1000, 2000)
+            ("ses_null", "proj_1", None, "Null Tool Test", 1000, 2000),
         )
-        
+
         # Insert valid tool
-        data = json.dumps({
-            "type": "tool",
-            "tool": "read",
-            "state": {"status": "completed"}
-        })
+        data = json.dumps(
+            {"type": "tool", "tool": "read", "state": {"status": "completed"}}
+        )
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_valid", "msg_1", "ses_null", 1000, 1000, data)
+            ("prt_valid", "msg_1", "ses_null", 1000, 1000, data),
         )
-        
+
         # Insert tool with null tool name (missing 'tool' field)
-        data = json.dumps({
-            "type": "tool",
-            "state": {"status": "completed"}
-        })
+        data = json.dumps({"type": "tool", "state": {"status": "completed"}})
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_null_tool", "msg_1", "ses_null", 2000, 2000, data)
+            ("prt_null_tool", "msg_1", "ses_null", 2000, 2000, data),
         )
-        
+
         conn.commit()
         conn.close()
-        
+
         # Should not raise and should only count valid tool
-        stats = SQLiteProcessor.load_tool_usage_for_sessions(
-            ["ses_null"], db_path
-        )
-        
+        stats = SQLiteProcessor.load_tool_usage_for_sessions(["ses_null"], db_path)
+
         assert len(stats) == 1
         assert stats[0].tool_name == "read"
 
@@ -343,10 +324,7 @@ class TestToolUsageStatsModel:
     def test_success_rate_calculation(self):
         """Test success rate is calculated correctly."""
         stats = ToolUsageStats(
-            tool_name="test",
-            total_calls=10,
-            success_count=8,
-            failure_count=2
+            tool_name="test", total_calls=10, success_count=8, failure_count=2
         )
         assert stats.success_rate == 80.0
 
@@ -372,7 +350,7 @@ class TestLoadToolUsageByModelForSessions:
         db_path = tmp_path / "test_opencode.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
+
         conn.execute("""
             CREATE TABLE session (
                 id TEXT PRIMARY KEY,
@@ -383,7 +361,7 @@ class TestLoadToolUsageByModelForSessions:
                 time_updated INTEGER NOT NULL
             )
         """)
-        
+
         conn.execute("""
             CREATE TABLE message (
                 id TEXT PRIMARY KEY,
@@ -393,7 +371,7 @@ class TestLoadToolUsageByModelForSessions:
                 data TEXT NOT NULL
             )
         """)
-        
+
         conn.execute("""
             CREATE TABLE part (
                 id TEXT PRIMARY KEY,
@@ -404,117 +382,178 @@ class TestLoadToolUsageByModelForSessions:
                 data TEXT NOT NULL
             )
         """)
-        
+
         conn.execute(
             "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_model_test", "proj_1", None, "Model Test", 1000, 2000)
+            ("ses_model_test", "proj_1", None, "Model Test", 1000, 2000),
         )
-        
+
         conn.execute(
             "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
-            ("msg_1", "ses_model_test", 1000, 1000, json.dumps({"role": "assistant", "modelID": "claude-3-5-sonnet-20241022"}))
+            (
+                "msg_1",
+                "ses_model_test",
+                1000,
+                1000,
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "modelID": "claude-3-5-sonnet-20241022",
+                        "tokens": {
+                            "input": 500,
+                            "output": 250,
+                            "cache": {"read": 1000, "write": 50},
+                        },
+                    }
+                ),
+            ),
         )
-        
+
         conn.execute(
             "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
-            ("msg_2", "ses_model_test", 2000, 2000, json.dumps({"role": "assistant", "modelID": "claude-3-5-haiku-20240307"}))
+            (
+                "msg_2",
+                "ses_model_test",
+                2000,
+                2000,
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "modelID": "claude-3-5-haiku-20240307",
+                        "tokens": {
+                            "input": 90,
+                            "output": 30,
+                            "cache": {"read": 300, "write": 60},
+                        },
+                    }
+                ),
+            ),
         )
-        
+
         for i, status in enumerate(["completed", "completed", "error"]):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "bash",
-                "state": {"status": status}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "bash", "state": {"status": status}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_sonnet_bash_{i}", "msg_1", "ses_model_test", 1000 + i, 1000 + i, data)
+                (
+                    f"prt_sonnet_bash_{i}",
+                    "msg_1",
+                    "ses_model_test",
+                    1000 + i,
+                    1000 + i,
+                    data,
+                ),
             )
-        
+
         for i in range(2):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "read",
-                "state": {"status": "completed"}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "read", "state": {"status": "completed"}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_sonnet_read_{i}", "msg_1", "ses_model_test", 2000 + i, 2000 + i, data)
+                (
+                    f"prt_sonnet_read_{i}",
+                    "msg_1",
+                    "ses_model_test",
+                    2000 + i,
+                    2000 + i,
+                    data,
+                ),
             )
-        
+
         for i, status in enumerate(["completed", "error", "error"]):
-            data = json.dumps({
-                "type": "tool",
-                "tool": "edit",
-                "state": {"status": status}
-            })
+            data = json.dumps(
+                {"type": "tool", "tool": "edit", "state": {"status": status}}
+            )
             conn.execute(
                 "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-                (f"prt_haiku_edit_{i}", "msg_2", "ses_model_test", 3000 + i, 3000 + i, data)
+                (
+                    f"prt_haiku_edit_{i}",
+                    "msg_2",
+                    "ses_model_test",
+                    3000 + i,
+                    3000 + i,
+                    data,
+                ),
             )
-        
-        data = json.dumps({
-            "type": "tool",
-            "tool": "bash",
-            "state": {"status": "running"}
-        })
+
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "running"}}
+        )
         conn.execute(
             "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_haiku_running", "msg_2", "ses_model_test", 4000, 4000, data)
+            ("prt_haiku_running", "msg_2", "ses_model_test", 4000, 4000, data),
         )
-        
+
         conn.commit()
         conn.close()
-        
+
         return db_path
 
     def test_groups_tools_by_model(self, temp_db_with_messages: Path):
         """Test that tools are grouped correctly by model."""
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
         from ocmonitor.models.tool_usage import ModelToolUsage
-        
+
         stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
             ["ses_model_test"], temp_db_with_messages
         )
-        
+
         assert len(stats) == 2
-        
+
         stats_by_model = {s.model_name: s for s in stats}
-        
+
         assert "claude-3-5-sonnet-20241022" in stats_by_model
         sonnet = stats_by_model["claude-3-5-sonnet-20241022"]
         assert sonnet.total_calls == 5
         assert len(sonnet.tool_stats) == 2
-        
+
         sonnet_tools = {t.tool_name: t for t in sonnet.tool_stats}
         assert "bash" in sonnet_tools
         assert sonnet_tools["bash"].total_calls == 3
         assert sonnet_tools["bash"].success_count == 2
         assert sonnet_tools["bash"].failure_count == 1
-        
+        assert sonnet_tools["bash"].input_tokens == 300
+        assert sonnet_tools["bash"].output_tokens == 150
+        assert sonnet_tools["bash"].cache_read_tokens == 600
+        assert sonnet_tools["bash"].cache_write_tokens == 30
+        assert sonnet_tools["bash"].total_tokens == 1080
+
+        assert sonnet_tools["read"].input_tokens == 200
+        assert sonnet_tools["read"].output_tokens == 100
+        assert sonnet_tools["read"].cache_read_tokens == 400
+        assert sonnet_tools["read"].cache_write_tokens == 20
+        assert sonnet_tools["read"].total_tokens == 720
+
         assert "claude-3-5-haiku-20240307" in stats_by_model
         haiku = stats_by_model["claude-3-5-haiku-20240307"]
         assert haiku.total_calls == 3
         assert len(haiku.tool_stats) == 1
-        
+
         haiku_tools = {t.tool_name: t for t in haiku.tool_stats}
         assert "edit" in haiku_tools
         assert haiku_tools["edit"].total_calls == 3
         assert haiku_tools["edit"].success_count == 1
         assert haiku_tools["edit"].failure_count == 2
+        assert haiku_tools["edit"].input_tokens == 90
+        assert haiku_tools["edit"].output_tokens == 30
+        assert haiku_tools["edit"].cache_read_tokens == 300
+        assert haiku_tools["edit"].cache_write_tokens == 60
+        assert haiku_tools["edit"].total_tokens == 480
 
     def test_excludes_running_status(self, temp_db_with_messages: Path):
         """Test that running status tools are excluded."""
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
+
         stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
             ["ses_model_test"], temp_db_with_messages
         )
-        
+
         haiku = next(s for s in stats if s.model_name == "claude-3-5-haiku-20240307")
-        
+
         bash_stat = next((t for t in haiku.tool_stats if t.tool_name == "bash"), None)
-        
+
         assert bash_stat is None
 
     def test_handles_nested_modelID(self, tmp_path: Path):
@@ -522,7 +561,7 @@ class TestLoadToolUsageByModelForSessions:
         db_path = tmp_path / "test_nested.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
+
         conn.execute("""
             CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, title TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL)
         """)
@@ -532,53 +571,73 @@ class TestLoadToolUsageByModelForSessions:
         conn.execute("""
             CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)
         """)
-        
-        conn.execute("INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_nested", "proj_1", None, "Nested Test", 1000, 2000))
-        
-        conn.execute("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
-            ("msg_nested", "ses_nested", 1000, 1000, json.dumps({"role": "assistant", "model": {"modelID": "nested-model-v1"}})))
-        
-        data = json.dumps({"type": "tool", "tool": "bash", "state": {"status": "completed"}})
-        conn.execute("INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_nested", "msg_nested", "ses_nested", 1000, 1000, data))
-        
+
+        conn.execute(
+            "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
+            ("ses_nested", "proj_1", None, "Nested Test", 1000, 2000),
+        )
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+            (
+                "msg_nested",
+                "ses_nested",
+                1000,
+                1000,
+                json.dumps(
+                    {"role": "assistant", "model": {"modelID": "nested-model-v1"}}
+                ),
+            ),
+        )
+
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "completed"}}
+        )
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+            ("prt_nested", "msg_nested", "ses_nested", 1000, 1000, data),
+        )
+
         conn.commit()
         conn.close()
-        
+
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
-        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(["ses_nested"], db_path)
-        
+
+        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
+            ["ses_nested"], db_path
+        )
+
         assert len(stats) == 1
         assert stats[0].model_name == "nested-model-v1"
 
     def test_empty_sessions_returns_empty(self, tmp_path: Path):
         """Test that empty session list returns empty list."""
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
-        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions([], tmp_path / "test.db")
+
+        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
+            [], tmp_path / "test.db"
+        )
         assert stats == []
 
     def test_sorts_models_by_total_calls(self, temp_db_with_messages: Path):
         """Test that models are sorted by total calls descending."""
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
+
         stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
             ["ses_model_test"], temp_db_with_messages
         )
-        
+
         assert stats[0].model_name == "claude-3-5-sonnet-20241022"
         assert stats[1].model_name == "claude-3-5-haiku-20240307"
 
     def test_sorts_tools_within_model(self, temp_db_with_messages: Path):
         """Test that tools within a model are sorted by total_calls descending."""
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
+
         stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
             ["ses_model_test"], temp_db_with_messages
         )
-        
+
         sonnet = next(s for s in stats if s.model_name == "claude-3-5-sonnet-20241022")
         assert sonnet.tool_stats[0].tool_name == "bash"
         assert sonnet.tool_stats[1].tool_name == "read"
@@ -588,27 +647,49 @@ class TestLoadToolUsageByModelForSessions:
         db_path = tmp_path / "test_unknown.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        
-        conn.execute("CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, title TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL)")
-        conn.execute("CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)")
-        conn.execute("CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)")
-        
-        conn.execute("INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
-            ("ses_unknown", "proj_1", None, "Unknown Test", 1000, 2000))
-        
-        conn.execute("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
-            ("msg_unknown", "ses_unknown", 1000, 1000, json.dumps({"role": "assistant"})))
-        
-        data = json.dumps({"type": "tool", "tool": "bash", "state": {"status": "completed"}})
-        conn.execute("INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
-            ("prt_unknown", "msg_unknown", "ses_unknown", 1000, 1000, data))
-        
+
+        conn.execute(
+            "CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, title TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)"
+        )
+
+        conn.execute(
+            "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
+            ("ses_unknown", "proj_1", None, "Unknown Test", 1000, 2000),
+        )
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+            (
+                "msg_unknown",
+                "ses_unknown",
+                1000,
+                1000,
+                json.dumps({"role": "assistant"}),
+            ),
+        )
+
+        data = json.dumps(
+            {"type": "tool", "tool": "bash", "state": {"status": "completed"}}
+        )
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+            ("prt_unknown", "msg_unknown", "ses_unknown", 1000, 1000, data),
+        )
+
         conn.commit()
         conn.close()
-        
+
         from ocmonitor.utils.sqlite_utils import SQLiteProcessor
-        
-        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(["ses_unknown"], db_path)
-        
+
+        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
+            ["ses_unknown"], db_path
+        )
+
         assert len(stats) == 1
         assert stats[0].model_name == "unknown"

--- a/tests/unit/test_sqlite_tool_usage.py
+++ b/tests/unit/test_sqlite_tool_usage.py
@@ -506,6 +506,7 @@ class TestLoadToolUsageByModelForSessions:
 
         assert "claude-3-5-sonnet-20241022" in stats_by_model
         sonnet = stats_by_model["claude-3-5-sonnet-20241022"]
+        assert sonnet.agent_name == "main"
         assert sonnet.total_calls == 5
         assert len(sonnet.tool_stats) == 2
 
@@ -528,6 +529,7 @@ class TestLoadToolUsageByModelForSessions:
 
         assert "claude-3-5-haiku-20240307" in stats_by_model
         haiku = stats_by_model["claude-3-5-haiku-20240307"]
+        assert haiku.agent_name == "main"
         assert haiku.total_calls == 3
         assert len(haiku.tool_stats) == 1
 
@@ -541,6 +543,95 @@ class TestLoadToolUsageByModelForSessions:
         assert haiku_tools["edit"].cache_read_tokens == 300
         assert haiku_tools["edit"].cache_write_tokens == 60
         assert haiku_tools["edit"].total_tokens == 480
+
+    def test_splits_same_model_by_agent(self, tmp_path: Path):
+        """Test same-model tool stats are split into separate agent groups."""
+        db_path = tmp_path / "test_agent_model.db"
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+
+        conn.execute(
+            "CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, title TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)"
+        )
+
+        conn.execute(
+            "INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)",
+            ("ses_agents", "proj_1", None, "Agent Split", 1000, 3000),
+        )
+
+        messages = [
+            ("msg_build", "build", 100, 50, 1000, 25, "bash"),
+            ("msg_lite", "lite-worker", 300, 75, 2000, 40, "read"),
+        ]
+        for index, (
+            msg_id,
+            agent,
+            input_tokens,
+            output_tokens,
+            cache_read,
+            cache_write,
+            tool,
+        ) in enumerate(messages):
+            conn.execute(
+                "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+                (
+                    msg_id,
+                    "ses_agents",
+                    1000 + index,
+                    1000 + index,
+                    json.dumps(
+                        {
+                            "role": "assistant",
+                            "agent": agent,
+                            "modelID": "gpt-5.5",
+                            "tokens": {
+                                "input": input_tokens,
+                                "output": output_tokens,
+                                "cache": {"read": cache_read, "write": cache_write},
+                            },
+                        }
+                    ),
+                ),
+            )
+            conn.execute(
+                "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    f"prt_{agent}",
+                    msg_id,
+                    "ses_agents",
+                    2000 + index,
+                    2000 + index,
+                    json.dumps(
+                        {"type": "tool", "tool": tool, "state": {"status": "completed"}}
+                    ),
+                ),
+            )
+
+        conn.commit()
+        conn.close()
+
+        from ocmonitor.utils.sqlite_utils import SQLiteProcessor
+
+        stats = SQLiteProcessor.load_tool_usage_by_model_for_sessions(
+            ["ses_agents"], db_path
+        )
+
+        assert len(stats) == 2
+
+        by_agent = {s.agent_name: s for s in stats}
+        assert set(by_agent) == {"build", "lite-worker"}
+        assert by_agent["build"].model_name == "gpt-5.5"
+        assert by_agent["build"].tool_stats[0].tool_name == "bash"
+        assert by_agent["build"].tool_stats[0].total_tokens == 1175
+        assert by_agent["lite-worker"].model_name == "gpt-5.5"
+        assert by_agent["lite-worker"].tool_stats[0].tool_name == "read"
+        assert by_agent["lite-worker"].tool_stats[0].total_tokens == 2415
 
     def test_excludes_running_status(self, temp_db_with_messages: Path):
         """Test that running status tools are excluded."""

--- a/tests/unit/test_sqlite_utils.py
+++ b/tests/unit/test_sqlite_utils.py
@@ -105,11 +105,28 @@ class TestParseMessageData:
 
     def test_nested_null_model_id_falls_back_to_unknown(self):
         """Null nested model.modelID in SQLite payload should fall back to unknown."""
-        message_data = json.dumps(
-            {"role": "assistant", "model": {"modelID": None}}
-        )
+        message_data = json.dumps({"role": "assistant", "model": {"modelID": None}})
 
         interaction = SQLiteProcessor.parse_message_data(message_data, "ses_test")
 
         assert interaction is not None
         assert interaction.model_id == "unknown"
+
+    def test_parse_message_data_preserves_sqlite_message_metadata(self):
+        """SQLite message metadata should be available for turn detail part lookup."""
+        message_data = json.dumps(
+            {"role": "assistant", "modelID": "test-model", "tokens": {"input": 1}}
+        )
+
+        interaction = SQLiteProcessor.parse_message_data(
+            message_data,
+            "ses_test",
+            message_id="msg_test",
+            time_created=123,
+            time_updated=456,
+        )
+
+        assert interaction is not None
+        assert interaction.raw_data["_message_id"] == "msg_test"
+        assert interaction.raw_data["_message_time_created"] == 123
+        assert interaction.raw_data["_message_time_updated"] == 456


### PR DESCRIPTION
## Problem

The `live` command's `--pick` flag shows an interactive picker listing all active and recent workflows, but there was no way to limit how many workflows appear. When users had many historical workflows, the picker became cluttered and hard to navigate.

Additionally, a hardcoded `[:5]` cap in the workflow retrieval methods meant that even when a limit parameter was passed, it was silently truncated to 5 — making `--last 10` show only 5 workflows.

## Change

Adds a `--last N` option to the `live` command that limits the number of workflows shown in the interactive picker (most recent N only).

### Behavior

```bash
# Default: shows up to 5 workflows in picker
ocmonitor live --pick -i 1

# Show only 2 workflows
ocmonitor live --pick --last 2 -i 1

# Show up to 10 workflows
ocmonitor live --pick --last 10 -i 1

# Without --pick, --last has no effect (auto-selects most recent workflow)
ocmonitor live -i 1 --last 10
```

### Implementation

The `last` parameter flows through the full chain:
`CLI --last` → `_prompt_workflow_selection(last=...)` → `pick_*_workflow(last=...)` → `*_get_*_workflows(limit=...)` → data fetch limit + final slice.

Fixes three hardcoded caps:
- `[:5]` in `_get_sqlite_active_workflows` and `_get_file_active_workflows`
- `limit=5` in `SQLiteProcessor.get_recent_workflows()` call
- Scales session load in file mode (`limit * 10`) since multiple sessions group into one workflow

Backward compatible: when `--last` is omitted, behavior is identical to before (default 5 cap).

## Testing

- All 392 existing tests pass
- New integration test `test_live_last_limits_picker_workflows` verifies the limit parameter reaches the workflow retrieval layer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recent-turn inspection with pagination, detailed turn statistics, and pause/resume support in the live dashboard.
  * Added workflow filtering with `--source` and `--last` options.
  * Added burn-rate monitoring and richer agent, model, tool, token, cost, and context metrics.
  * Improved workflow selection and SQLite-based workflow analytics.

* **Bug Fixes**
  * Prevented errors when session timing data is unavailable.
  * Improved timestamp handling and activity detection across data sources.

* **Tests**
  * Expanded coverage for live turn inspection, workflow retrieval, metadata handling, and token analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->