### PR TITLE
feat(live): default to full-screen monitoring

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -486,14 +486,19 @@ ocmonitor projects ~/.local/share/opencode/storage/message --format csv
 ### 4. Live Monitoring Commands
 
 #### `ocmonitor live <path>`
-Real-time monitoring dashboard that updates automatically.
+Real-time monitoring dashboard that updates automatically. By default, it uses a
+full-screen display and restores the terminal prompt when you exit. Use `--inline`
+to keep dashboard output in the normal terminal buffer.
 
 ```bash
-# Start live monitoring (updates every 5 seconds)
+# Start live monitoring (updates every 3 seconds by default)
 ocmonitor live ~/.local/share/opencode/storage/message
 
 # Custom refresh interval (in seconds)
-ocmonitor live ~/.local/share/opencode/storage/message --refresh 10
+ocmonitor live ~/.local/share/opencode/storage/message --interval 10
+
+# Keep dashboard output in the normal terminal buffer
+ocmonitor live ~/.local/share/opencode/storage/message --inline
 ```
 
 **Features:**

--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ Supported days: `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturda
 
 #### `ocmonitor live <path>`
 
-Real-time monitoring dashboard that updates automatically.
+Real-time monitoring dashboard that updates automatically. By default, it uses a
+full-screen display and restores the terminal prompt when you exit. Use `--inline`
+to keep dashboard output in the normal terminal buffer.
 
 ```bash
 # Start live monitoring (updates every 3 seconds by default)
@@ -260,6 +262,9 @@ ocmonitor live
 
 # Custom update interval (in seconds)
 ocmonitor live --interval 10
+
+# Keep dashboard output in the normal terminal buffer
+ocmonitor live --inline
 
 # Pick a workflow by readable title before launching
 # (also enables interactive switching controls by default)

--- a/ocmonitor/cli.py
+++ b/ocmonitor/cli.py
@@ -482,9 +482,18 @@ def _display_validation_results(console, validation: dict, ctx) -> bool:
 @cli.command()
 @click.argument("path", type=click.Path(exists=True), required=False)
 @click.option(
-    "--interval", "-i", type=int, default=None, help="Update interval in seconds"
+    "--interval",
+    "-i",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Update interval in seconds (minimum: 1)",
 )
 @click.option("--no-color", is_flag=True, help="Disable colored output")
+@click.option(
+    "--inline",
+    is_flag=True,
+    help="Use normal terminal-buffer output instead of the default full-screen display",
+)
 @click.option(
     "--pick",
     is_flag=True,
@@ -512,6 +521,7 @@ def live(
     path: Optional[str],
     interval: Optional[int],
     no_color: bool,
+    inline: bool,
     pick: bool,
     session_id: Optional[str],
     interactive_switch: bool,
@@ -578,6 +588,7 @@ def live(
                 interval,
                 selected_session_id=selected_session_id,
                 interactive_switch=interactive_switch,
+                inline=inline,
             )
         elif mode == "files":
             if not path:
@@ -590,6 +601,7 @@ def live(
                 interval,
                 selected_session_id=selected_session_id,
                 interactive_switch=interactive_switch,
+                inline=inline,
             )
 
     except KeyboardInterrupt:

--- a/ocmonitor/services/live_monitor.py
+++ b/ocmonitor/services/live_monitor.py
@@ -821,6 +821,7 @@ class LiveMonitor:
         refresh_interval: int = 5,
         selected_session_id: Optional[str] = None,
         interactive_switch: bool = False,
+        inline: bool = False,
     ):
         """Start live monitoring of all active workflows (main session + sub-agents).
 
@@ -831,6 +832,7 @@ class LiveMonitor:
             refresh_interval: Update interval in seconds
             selected_session_id: Optional workflow/main/sub-agent ID to pin
             interactive_switch: Enable command-driven live workflow switching
+            inline: Keep dashboard output in the normal terminal buffer
         """
         try:
             active_workflows = self._get_file_active_workflows(
@@ -902,6 +904,7 @@ class LiveMonitor:
                 ),
                 refresh_per_second=10,
                 console=self.console,
+                screen=not inline,
             ) as live:
                 descriptors = self._describe_file_workflows(active_workflows)
                 next_refresh_at = time.time() + refresh_interval
@@ -1481,6 +1484,7 @@ class LiveMonitor:
         refresh_interval: int = 5,
         selected_session_id: Optional[str] = None,
         interactive_switch: bool = False,
+        inline: bool = False,
     ):
         """Start live monitoring of all active workflows from SQLite (v1.2.0+).
 
@@ -1491,6 +1495,7 @@ class LiveMonitor:
             refresh_interval: Update interval in seconds
             selected_session_id: Optional workflow/main/sub-agent ID to pin
             interactive_switch: Enable command-driven live workflow switching
+            inline: Keep dashboard output in the normal terminal buffer
         """
         try:
             # Check if SQLite is available
@@ -1571,6 +1576,7 @@ class LiveMonitor:
                 ),
                 refresh_per_second=10,
                 console=self.console,
+                screen=not inline,
             ) as live:
                 descriptors = self._describe_sqlite_workflows(active_workflows)
                 next_refresh_at = time.time() + refresh_interval

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -623,6 +623,11 @@ class TestLiveCommand:
         captured = {}
 
         def fake_start_monitoring(self, *args, **kwargs):
+            """A fake start_monitoring replacement used to capture call args.
+
+            This test-local stub records positional and keyword arguments so the
+            test can assert that the CLI forwarded the `--inline` flag correctly.
+            """
             captured["args"] = args
             captured["kwargs"] = kwargs
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -584,6 +584,76 @@ class TestSessionCommand:
 class TestLiveCommand:
     """Tests for live command selection and precedence."""
 
+    def test_live_help_describes_inline_as_the_normal_buffer_fallback(self):
+        """Help must distinguish inline output from the default full-screen view."""
+        runner = CliRunner()
+
+        result = runner.invoke(cli, ["live", "--help"])
+
+        assert result.exit_code == 0
+        normalized_help = " ".join(result.output.split())
+        assert "normal terminal-buffer output" in normalized_help
+        assert "default full-screen display" in normalized_help
+
+    @pytest.mark.parametrize("interval", ["0", "-1"])
+    def test_live_rejects_nonpositive_update_intervals(self, interval):
+        """The monitor must not accept intervals that cause a busy polling loop."""
+        runner = CliRunner()
+
+        result = runner.invoke(cli, ["live", "--interval", interval])
+
+        assert result.exit_code == 2
+        assert "not in the range" in result.output
+        assert ">=1" in result.output
+
+    @pytest.mark.parametrize(
+        ("source", "method_name", "inline"),
+        [
+            ("files", "start_monitoring", False),
+            ("files", "start_monitoring", True),
+            ("sqlite", "start_sqlite_workflow_monitoring", False),
+            ("sqlite", "start_sqlite_workflow_monitoring", True),
+        ],
+    )
+    def test_live_forwards_inline_mode_for_each_source(
+        self, mock_sessions_dir, source, method_name, inline
+    ):
+        """The CLI forwards full-screen default and inline fallback to each monitor."""
+        runner = CliRunner()
+        captured = {}
+
+        def fake_start_monitoring(self, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+        validation = {
+            "valid": True,
+            "issues": [],
+            "warnings": [],
+            "info": {
+                "sqlite": {"available": source == "sqlite"},
+                "files": {"available": source == "files"},
+            },
+        }
+        command = ["live"]
+        if source == "files":
+            command.append(str(mock_sessions_dir))
+        command.extend(["--source", source])
+        if inline:
+            command.append("--inline")
+
+        with patch(
+            "ocmonitor.services.live_monitor.LiveMonitor.validate_monitoring_setup",
+            return_value=validation,
+        ), patch(
+            f"ocmonitor.services.live_monitor.LiveMonitor.{method_name}",
+            new=fake_start_monitoring,
+        ):
+            result = runner.invoke(cli, command)
+
+        assert result.exit_code == 0
+        assert captured["kwargs"]["inline"] is inline
+
     def test_live_with_pick_uses_picker_selection(self, mock_sessions_dir):
         runner = CliRunner()
         captured = {}

--- a/tests/unit/test_live_monitor.py
+++ b/tests/unit/test_live_monitor.py
@@ -14,14 +14,30 @@ class TestLiveMonitorDisplayMode:
         live_instances = []
 
         class FakeLive:
+            """A minimal context manager used to mimic Rich Live in tests.
+
+            Instances are appended to the outer `live_instances` list and
+            construction kwargs are captured for assertions.
+            """
             def __init__(self, *args, **kwargs):
+                """Initialize the fake live instance and record the kwargs.
+
+                The instance is appended to the enclosing `live_instances` list
+                so tests can assert how the Live context was constructed.
+                """
                 self.kwargs = kwargs
                 live_instances.append(self)
 
             def __enter__(self):
+                """Enter the context manager and return this instance."""
                 return self
 
             def __exit__(self, exc_type, exc_value, traceback):
+                """Exit the context manager and do not suppress exceptions.
+
+                Returning False ensures any exception (e.g., KeyboardInterrupt)
+                propagates to the test.
+                """
                 return False
 
         monkeypatch.setattr("ocmonitor.services.live_monitor.Live", FakeLive)
@@ -30,6 +46,11 @@ class TestLiveMonitorDisplayMode:
     def test_file_monitor_uses_full_screen_by_default_and_inline_when_requested(
         self, monkeypatch, tmp_path
     ):
+        """Verify file-based LiveMonitor uses full-screen by default and inline when requested.
+
+        The test asserts that the Live context is created with `screen=True` for the
+        default call and `screen=False` when invoked with `inline=True`.
+        """
         workflow = SimpleNamespace(
             workflow_id="file-workflow",
             main_session=SimpleNamespace(session_id="file-session", files=[]),
@@ -66,6 +87,11 @@ class TestLiveMonitorDisplayMode:
     def test_sqlite_monitor_uses_full_screen_by_default_and_inline_when_requested(
         self, monkeypatch, tmp_path
     ):
+        """Verify SQLite-based LiveMonitor uses full-screen by default and inline when requested.
+
+        The test asserts that the Live context is created with `screen=True` for the
+        default call and `screen=False` when invoked with `inline=True`.
+        """
         workflow = {
             "workflow_id": "sqlite-workflow",
             "main_session": SimpleNamespace(

--- a/tests/unit/test_live_monitor.py
+++ b/tests/unit/test_live_monitor.py
@@ -5,6 +5,113 @@ from ocmonitor.config import PathsConfig
 from ocmonitor.services.live_monitor import LiveMonitor
 
 
+class TestLiveMonitorDisplayMode:
+    """Tests for Rich Live full-screen and inline setup."""
+
+    @staticmethod
+    def _record_live_instances(monkeypatch):
+        """Replace Rich Live and return every instance created by a monitor."""
+        live_instances = []
+
+        class FakeLive:
+            def __init__(self, *args, **kwargs):
+                self.kwargs = kwargs
+                live_instances.append(self)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+        monkeypatch.setattr("ocmonitor.services.live_monitor.Live", FakeLive)
+        return live_instances
+
+    def test_file_monitor_uses_full_screen_by_default_and_inline_when_requested(
+        self, monkeypatch, tmp_path
+    ):
+        workflow = SimpleNamespace(
+            workflow_id="file-workflow",
+            main_session=SimpleNamespace(session_id="file-session", files=[]),
+            all_sessions=[SimpleNamespace(session_id="file-session")],
+            has_sub_agents=False,
+            display_title="File workflow",
+            project_name="project",
+            session_count=1,
+            sub_agent_count=0,
+        )
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        monkeypatch.setattr(
+            monitor, "_get_file_active_workflows", lambda *args, **kwargs: [workflow]
+        )
+        monkeypatch.setattr(monitor, "_generate_workflow_dashboard", lambda *args: None)
+        live_instances = self._record_live_instances(monkeypatch)
+        monkeypatch.setattr(
+            "ocmonitor.services.live_monitor.time.time",
+            lambda: (_ for _ in ()).throw(KeyboardInterrupt),
+        )
+
+        monitor.start_monitoring(str(tmp_path))
+        monitor.start_monitoring(str(tmp_path), inline=True)
+
+        assert [instance.kwargs["screen"] for instance in live_instances] == [
+            True,
+            False,
+        ]
+        assert all(
+            instance.kwargs["refresh_per_second"] == 10
+            for instance in live_instances
+        )
+
+    def test_sqlite_monitor_uses_full_screen_by_default_and_inline_when_requested(
+        self, monkeypatch, tmp_path
+    ):
+        workflow = {
+            "workflow_id": "sqlite-workflow",
+            "main_session": SimpleNamespace(
+                session_id="sqlite-session",
+                display_title="SQLite workflow",
+                project_name="project",
+                files=[],
+                start_time=None,
+            ),
+            "all_sessions": [SimpleNamespace(session_id="sqlite-session")],
+            "has_sub_agents": False,
+            "display_title": "SQLite workflow",
+            "project_name": "project",
+            "session_count": 1,
+            "sub_agent_count": 0,
+        }
+        monitor = LiveMonitor(pricing_data={}, init_from_db=False)
+        monkeypatch.setattr(
+            "ocmonitor.services.live_monitor.SQLiteProcessor.find_database_path",
+            lambda: str(tmp_path / "opencode.db"),
+        )
+        monkeypatch.setattr(
+            monitor, "_get_sqlite_active_workflows", lambda *args, **kwargs: [workflow]
+        )
+        monkeypatch.setattr(
+            monitor, "_generate_sqlite_workflow_dashboard", lambda *args: None
+        )
+        live_instances = self._record_live_instances(monkeypatch)
+        monkeypatch.setattr(
+            "ocmonitor.services.live_monitor.time.time",
+            lambda: (_ for _ in ()).throw(KeyboardInterrupt),
+        )
+
+        monitor.start_sqlite_workflow_monitoring()
+        monitor.start_sqlite_workflow_monitoring(inline=True)
+
+        assert [instance.kwargs["screen"] for instance in live_instances] == [
+            True,
+            False,
+        ]
+        assert all(
+            instance.kwargs["refresh_per_second"] == 10
+            for instance in live_instances
+        )
+
+
 class TestMultiWorkflowTracking:
     def test_tracks_multiple_active_workflows(self, monkeypatch, tmp_path):
         active_workflow_a = {


### PR DESCRIPTION
## Summary
- Make `ocmonitor live` use Rich's alternate-screen display by default.
- Add `--inline` to retain normal terminal-buffer output.
- Cover file/SQLite monitor modes, interval validation, and docs.
- Fixes **flickering bug** for every update !!

## Testing
- `python -m pytest -q`
- `ocmonitor live --help`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an `--inline` option to keep live dashboard output in the normal terminal buffer.
  - Updated live monitoring CLI behavior to support inline vs full-screen output.

- **Improvements**
  - Default live dashboard display is now full-screen and restores the terminal prompt on exit.
  - Default auto-refresh interval is now 3 seconds.
  - `--interval` now enforces a minimum value of 1.
  - Updated README and live monitoring documentation with revised flags and new examples.

- **Tests**
  - Added CLI and unit tests covering inline mode, interval validation, and correct forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->